### PR TITLE
defining `baseUvPolyTpCompDomEquiv`

### DIFF
--- a/GroupoidModel/ForMathlib.lean
+++ b/GroupoidModel/ForMathlib.lean
@@ -769,11 +769,6 @@ variable {Γ : Type u₂} [Category.{v₂} Γ] {Δ : Type u₃} [Category.{v₃}
 end Grothendieck
 end CategoryTheory
 
-@[simp]
-theorem PSigma.heq_mk_iff {α : Sort u} {β : α → Sort v} {β' : α → Sort v}
-    (a b : α) (x : β a) (y : β' b) :
-    HEq (PSigma.mk a x) (PSigma.mk b y) ↔ (a = b ∧ HEq x y) :=
-  sorry
 
 def Equiv.psigmaCongrProp {α₁ α₂} {β₁ : α₁ → Prop} {β₂ : α₂ → Prop} (f : α₁ ≃ α₂)
     (F : ∀ a, β₁ a ↔ β₂ (f a)) : PSigma β₁ ≃ PSigma β₂ where
@@ -794,6 +789,6 @@ noncomputable def pullbackHomEquiv {A B C: 𝒞} {Γ : 𝒞} {f : A ⟶ C} {g : 
   toFun h := ⟨h ≫ pullback.fst f g, h ≫ pullback.snd f g, by simp[pullback.condition]⟩
   invFun x := pullback.lift x.1 x.2.1 x.2.2
   left_inv _ := pullback.hom_ext (by simp) (by simp)
-  right_inv := by rintro ⟨_,_,_⟩; simp
+  right_inv := by rintro ⟨_,_,_⟩; congr!; simp; simp
 
 end CategoryTheory.Limits

--- a/GroupoidModel/ForMathlib.lean
+++ b/GroupoidModel/ForMathlib.lean
@@ -768,3 +768,13 @@ variable {Γ : Type u₂} [Category.{v₂} Γ] {Δ : Type u₃} [Category.{v₃}
 
 end Grothendieck
 end CategoryTheory
+
+/-- Transporting a sigma type through an equivalence of the base and a family of equivalences
+of matching fibers -/
+def Equiv.psigmaCongrProp {α₁ α₂} {β₁ : α₁ → Prop} {β₂ : α₂ → Prop} (f : α₁ ≃ α₂)
+    (F : ∀ a, β₁ a ↔ β₂ (f a)) : PSigma β₁ ≃ PSigma β₂ where
+  toFun x := .mk (f x.1) (by rw [← F]; exact x.2)
+  invFun x := .mk (f.symm x.1) (by
+    simp only [F, apply_symm_apply]; exact x.2)
+  left_inv _ := by simp
+  right_inv _ := by simp

--- a/GroupoidModel/ForMathlib.lean
+++ b/GroupoidModel/ForMathlib.lean
@@ -774,3 +774,26 @@ theorem PSigma.heq_mk_iff {α : Sort u} {β : α → Sort v} {β' : α → Sort 
     (a b : α) (x : β a) (y : β' b) :
     HEq (PSigma.mk a x) (PSigma.mk b y) ↔ (a = b ∧ HEq x y) :=
   sorry
+
+def Equiv.psigmaCongrProp {α₁ α₂} {β₁ : α₁ → Prop} {β₂ : α₂ → Prop} (f : α₁ ≃ α₂)
+    (F : ∀ a, β₁ a ↔ β₂ (f a)) : PSigma β₁ ≃ PSigma β₂ where
+  toFun x := .mk (f x.1) (by rw [← F]; exact x.2)
+  invFun x := .mk (f.symm x.1) (by
+    simp only [F, apply_symm_apply]; exact x.2)
+  left_inv _ := by simp
+  right_inv _ := by simp
+
+
+namespace CategoryTheory.Limits
+
+variable {𝒞 : Type u} [Category.{v} 𝒞] [HasPullbacks 𝒞]
+
+noncomputable def pullbackHomEquiv {A B C: 𝒞} {Γ : 𝒞} {f : A ⟶ C} {g : B ⟶ C} :
+    (Γ ⟶ pullback f g) ≃
+    (fst : Γ ⟶ A) × (snd : Γ ⟶ B) ×' (fst ≫ f = snd ≫ g) where
+  toFun h := ⟨h ≫ pullback.fst f g, h ≫ pullback.snd f g, by simp[pullback.condition]⟩
+  invFun x := pullback.lift x.1 x.2.1 x.2.2
+  left_inv _ := pullback.hom_ext (by simp) (by simp)
+  right_inv := by rintro ⟨_,_,_⟩; simp
+
+end CategoryTheory.Limits

--- a/GroupoidModel/ForPoly.lean
+++ b/GroupoidModel/ForPoly.lean
@@ -11,60 +11,50 @@ namespace UvPoly
 
 variable {𝒞} [Category 𝒞] [HasTerminal 𝒞] [HasPullbacks 𝒞]
 
--- TODO: rm this and just use `equiv` directly
-/-- Universal property of the polynomial functor. -/
-def _root_.UvPoly.equiv' {E B : 𝒞} (P : UvPoly E B) (Γ X : 𝒞) :
-    (Γ ⟶ P.functor.obj X) ≃ Σ b : Γ ⟶ B, pullback P.p b ⟶ X :=
-  (UvPoly.equiv P Γ X).trans <|
-  Equiv.sigmaCongrRight fun _ =>
-  ((yoneda.obj X).mapIso (pullbackSymmetry ..).op).toEquiv
+variable {E B : 𝒞} (P : UvPoly E B) (A : 𝒞)
 
-def genPb.snd {E B: 𝒞} (P : UvPoly E B) (X : 𝒞) : P.genPb X ⟶ E :=
-  pullback.snd (f := P.proj X) (g := P.p)
+-- TODO (JH) make issue
+theorem pair_proj {Γ} (b : Γ ⟶ B) (e : pullback b P.p ⟶ A) :
+    P.pairPoly b e ≫ P.proj _ = b := by
+  sorry
 
-theorem genPb.condition {E B A: 𝒞} (P : UvPoly E B) : genPb.snd P A ≫ P.p = genPb.fst P A ≫ P.proj A := by
+def genPb.snd : P.genPb A ⟶ E :=
+  pullback.snd (f := P.proj A) (g := P.p)
+
+variable {A}
+theorem genPb.condition :
+    genPb.snd P A ≫ P.p = genPb.fst P A ≫ P.proj A := by
   simp [genPb.fst,genPb.snd,pullback.condition]
 
-def compDomUP {Γ E B D A : 𝒞} {P : UvPoly E B} {Q : UvPoly D A} : (Γ ⟶ compDom P Q) ≃ (β : Γ ⟶ D) × (αB : Γ ⟶ genPb P A) ×' (β ≫ Q.p = αB ≫ genPb.u₂ P A) where
-  toFun f := ⟨f ≫ (pullback.fst Q.p (genPb.u₂ P A)), f ≫ (pullback.snd Q.p (genPb.u₂ P A)), by simp [pullback.condition (f := Q.p) (g := genPb.u₂ P A)]⟩
-  invFun := by
-    rintro ⟨β,αB,h⟩
-    exact pullback.lift β αB h
-  left_inv f := by
-    refine pullback.hom_ext ?_ ?_
-    . simp
-    . simp
-  right_inv := by
-    rintro ⟨β,αB,h⟩
-    simp
-
-def pullbackUP {A B C: 𝒞} (Γ : 𝒞) (f : A ⟶ C) (g : B ⟶ C) : (Γ ⟶ pullback f g) ≃ (fst : Γ ⟶ A) × (snd : Γ ⟶ B) ×' (fst ≫ f = snd ≫ g) where
-  toFun h := ⟨h ≫ pullback.fst f g, h ≫ pullback.snd f g, by simp[pullback.condition]⟩
-  invFun := by
-    rintro ⟨fst,snd,h⟩
-    exact pullback.lift fst snd h
-  left_inv f := by
-    refine pullback.hom_ext ?_ ?_
-    . simp[genPb.fst]
-    . simp[genPb.snd]
-  right_inv := by
-    rintro ⟨fst,snd,h⟩
-    simp[genPb.fst,genPb.snd]
-
-def compDomUP' {Γ E B D A : 𝒞} {P : UvPoly E B} {Q : UvPoly D A} : (Γ ⟶ compDom P Q) ≃ (β : Γ ⟶ D) × (fst : Γ ⟶ P.functor.obj A) × (snd : Γ ⟶ E) ×' (h : fst ≫ P.proj A = snd ≫ P.p) ×' (β ≫ Q.p = pullback.lift fst snd h ≫ genPb.u₂ P A) where
-  toFun f := ⟨f ≫ (pullback.fst Q.p (genPb.u₂ P A)), f ≫ (pullback.snd Q.p (genPb.u₂ P A)) ≫ genPb.fst P A, f ≫ (pullback.snd Q.p (genPb.u₂ P A)) ≫ genPb.snd P A, sorry⟩
-  invFun := by
-    rintro ⟨β,fst,snd,h,h'⟩
-    exact pullback.lift β (pullback.lift fst snd h) h'
-  left_inv f := by
-    refine pullback.hom_ext ?_ ?_
-    . simp
-    . refine pullback.hom_ext ?_ ?_
-      . simp[genPb.fst]
-      . simp[genPb.snd]
-  right_inv := by
-    rintro ⟨β,fst,snd,h,h'⟩
-    sorry
+def compDomEquiv {Γ E B D A : 𝒞} {P : UvPoly E B} {Q : UvPoly D A} :
+    (Γ ⟶ compDom P Q)
+    ≃ (AB : Γ ⟶ P.functor.obj A) × (α : Γ ⟶ E) × (β : Γ ⟶ D)
+    ×' (h : AB ≫ P.proj A = α ≫ P.p)
+    ×' (β ≫ Q.p = pullback.lift AB α h ≫ genPb.u₂ P A) :=
+  calc
+  _ ≃ (β : Γ ⟶ D) × (αB : Γ ⟶ genPb P A)
+  ×' (β ≫ Q.p = αB ≫ genPb.u₂ P A) := pullbackHomEquiv
+  _ ≃ (β : Γ ⟶ D) × (αB : (AB : Γ ⟶ P.functor.obj A) × (α : Γ ⟶ E) ×' AB ≫ P.proj A = α ≫ P.p) ×'
+      β ≫ Q.p = pullback.lift αB.1 αB.2.1 αB.2.2 ≫ genPb.u₂ P A :=
+    Equiv.sigmaCongrRight (fun β =>
+    calc
+    _ ≃
+    (αB : (AB : Γ ⟶ P.functor.obj A)
+    × (α : Γ ⟶ E)
+    ×' (AB ≫ P.proj A = α ≫ P.p))
+    ×' (β ≫ Q.p = pullback.lift αB.1 αB.2.1 αB.2.2 ≫ genPb.u₂ P A) :=
+      Equiv.psigmaCongrProp pullbackHomEquiv (fun αB => by
+        apply Eq.congr_right
+        congr 1
+        apply pullback.hom_ext
+        · simp [pullbackHomEquiv]
+        · simp [pullbackHomEquiv]))
+  _ ≃ _ := {
+      -- TODO should be general tactic for this?
+      toFun x := ⟨ x.2.1.1, x.2.1.2.1 , x.1 , x.2.1.2.2, x.2.2 ⟩
+      invFun x := ⟨ x.2.2.1 , ⟨ x.1, x.2.1 , x.2.2.2.1 ⟩ , x.2.2.2.2 ⟩
+      left_inv _ := rfl
+      right_inv _ := rfl }
 
 end UvPoly
 

--- a/GroupoidModel/Grothendieck/Groupoidal.lean
+++ b/GroupoidModel/Grothendieck/Groupoidal.lean
@@ -446,6 +446,34 @@ variable {Γ : Type u₂} [Category.{v₂} Γ] {Δ : Type u₃} [Category.{v₃}
 
 end
 
+/-- `sec` is the universal lift in the following diagram,
+  which is a section of `Groupoidal.forget`
+             α
+  ===== Γ -------α--------------¬
+ ‖      ↓ sec                   V
+ ‖   M.ext A ⋯ -------------> PGrpd
+ ‖      |                        |
+ ‖      |                        |
+ ‖   forget                  forgetToGrpd
+ ‖      |                        |
+ ‖      V                        V
+  ===== Γ --α ≫ forgetToGrpd--> Grpd
+-/
+def sec
+    {Γ : Grpd.{v₂,u₂}} (α : Γ ⥤ PGrpd.{v₁,u₁}) :
+    Γ ⥤ Groupoidal (α ⋙ PGrpd.forgetToGrpd) :=
+  Groupoidal.IsMegaPullback.lift α (Functor.id _) rfl
+
+@[simp] def sec_toPGrpd
+    {Γ : Grpd.{v₂,u₂}} (α : Γ ⥤ PGrpd.{v₁,u₁}) :
+    Groupoidal.sec α ⋙ Groupoidal.toPGrpd _ = α := by
+  simp [Groupoidal.sec]
+
+@[simp] def sec_forget
+    {Γ : Grpd.{v₂,u₂}} (α : Γ ⥤ PGrpd.{v₁,u₁}) :
+    Groupoidal.sec α ⋙ Grothendieck.forget _ = Functor.id _ :=
+  rfl
+
 end Groupoidal
 end Grothendieck
 end CategoryTheory

--- a/GroupoidModel/Groupoids/Basic.lean
+++ b/GroupoidModel/Groupoids/Basic.lean
@@ -72,12 +72,11 @@ abbrev yonedaCat : Cat.{u,u+1} ⥤ Ctx.{u}ᵒᵖ ⥤ Type (u + 1) :=
 instance yonedaCatPreservesLimits : PreservesLimits yonedaCat :=
   comp_preservesLimits _ _
 
-variable {Γ Δ : Ctx.{u}} {C D : Type (u+1)}
-  [Category.{u,u+1} C] [Category.{u,u+1} D]
+variable {Γ Δ : Ctx.{u}} {C D : Cat.{u,u+1}}
 
 /- The bijection y(Γ) → [-,C]   ≃   Γ ⥤ C -/
 def yonedaCatEquiv :
-    (yoneda.obj Γ ⟶ yonedaCat.obj (Cat.of C))
+    (yoneda.obj Γ ⟶ yonedaCat.obj C)
       ≃ Ctx.toGrpd.obj Γ ⥤ C :=
   Equiv.trans yonedaEquiv
     {toFun     := λ A ↦ ULift.upFunctor ⋙ A
@@ -86,23 +85,32 @@ def yonedaCatEquiv :
      right_inv := λ _ ↦ rfl}
 
 lemma yonedaCatEquiv_yonedaEquivSymm {Γ : Ctx}
-    (A : (yonedaCat.obj (Cat.of C)).obj (Opposite.op Γ)) :
+    (A : (yonedaCat.obj C).obj (Opposite.op Γ)) :
     yonedaCatEquiv (yonedaEquiv.symm A) = upFunctor ⋙ A := by
   congr
 
-theorem yonedaCatEquiv_naturality
-    (A : yoneda.obj Γ ⟶ yonedaCat.obj (Cat.of C)) (σ : Δ ⟶ Γ) :
-    (AsSmall.down.map σ) ⋙ yonedaCatEquiv A
-      = yonedaCatEquiv (yoneda.map σ ≫ A) := by
+theorem yonedaCatEquiv_naturality_left
+    (A : yoneda.obj Γ ⟶ yonedaCat.obj C) (σ : Δ ⟶ Γ) :
+    yonedaCatEquiv (yoneda.map σ ≫ A) =
+    (Ctx.toGrpd.map σ) ⋙ yonedaCatEquiv A:= by
   simp only [AsSmall.down_obj, AsSmall.down_map, yonedaCatEquiv,
     Functor.op_obj, Functor.comp_obj, Cat.of_α,
     Equiv.trans_apply, Equiv.coe_fn_mk, ← yonedaEquiv_naturality]
   rfl
 
-theorem yonedaCatEquiv_comp
-    (A : yoneda.obj Γ ⟶ yonedaCat.obj (Cat.of D)) (U : D ⥤ C) :
-    yonedaCatEquiv (A ≫ yonedaCat.map U) = yonedaCatEquiv A ⋙ U := by
-  aesop_cat
+theorem yonedaCatEquiv_naturality_right
+    (A : yoneda.obj Γ ⟶ yonedaCat.obj D) (U : D ⥤ C) :
+    yonedaCatEquiv (A ≫ yonedaCat.map U) = yonedaCatEquiv A ⋙ U := rfl
+
+theorem yonedaCatEquiv_symm_naturality_left
+    (A : Ctx.toGrpd.obj Γ ⥤ C) (σ : Δ ⟶ Γ) :
+    yoneda.map σ ≫ yonedaCatEquiv.symm A =
+    yonedaCatEquiv.symm (Ctx.toGrpd.map σ ⋙ A) := rfl
+
+theorem yonedaCatEquiv_symm_naturality_right
+    (A : Ctx.toGrpd.obj Γ ⥤ D) (U : D ⥤ C) :
+    yonedaCatEquiv.symm (A ⋙ U) =
+    yonedaCatEquiv.symm A ≫ yonedaCat.map U := rfl
 
 end yonedaCat
 
@@ -154,7 +162,7 @@ variable {Γ : Ctx.{u}} (A : yoneda.obj Γ ⟶ Ty)
 abbrev ext : Ctx := Ctx.ofGrpd.obj $ Grpd.of (Groupoidal (yonedaCatEquiv A))
 
 abbrev disp : ext A ⟶ Γ :=
-  AsSmall.up.map (Grothendieck.forget _)
+  Ctx.ofGrpd.map (Grothendieck.forget _)
 
 abbrev var : (y(ext A) : Psh Ctx) ⟶ Tm :=
   yonedaCatEquiv.symm (Groupoidal.toPGrpd (yonedaCatEquiv A))

--- a/GroupoidModel/Groupoids/NaturalModelBase.lean
+++ b/GroupoidModel/Groupoids/NaturalModelBase.lean
@@ -200,21 +200,10 @@ def baseUvPolyTpEquiv {Γ : Ctx.{u}} {C : Cat.{u,u+1}} :
     (base.Ptp.obj (yonedaCat.obj C)).obj (op Γ)
     ≃ (A : Ctx.toGrpd.obj Γ ⥤ Grpd.{u,u}) × (Groupoidal A ⥤ C) :=
   yonedaEquiv.symm.trans (
-  (uvPolyTpEquiv _ _ _).trans (
+  base.uvPolyTpEquiv.trans (
   Equiv.sigmaCongr
     yonedaCatEquiv
     (fun _ => yonedaCatEquiv)))
-
--- -- NOTE: maybe no need for this
--- /-- A specialization of the universal property of `genPb` to the natural model `base` -/
--- def baseGenPbEquiv {Γ : Ctx.{u}} {C : Cat.{u,u+1}} :
---     (UvPoly.genPb base.uvPolyTp (yonedaCat.obj C)).obj (op Γ)
---     ≃ (α : Ctx.toGrpd.obj Γ ⥤ PGrpd.{u,u})
---     × (Groupoidal (α ⋙ PGrpd.forgetToGrpd) ⥤ Grpd.{u,u}) :=
---   yonedaEquiv.symm.trans (
---   (base.genPbEquiv Γ (yonedaCat.obj C)).trans
---   (Equiv.sigmaCongr yonedaCatEquiv $ fun _ =>
---     yonedaCatEquiv))
 
 @[simp] theorem base_sec {Γ : Ctx.{u}} (α : y(Γ) ⟶ base.Tm) :
     base.sec α = ym(Ctx.ofGrpd.map (Groupoidal.sec (yonedaCatEquiv α))) :=
@@ -238,8 +227,8 @@ def baseUvPolyTpEquiv {Γ : Ctx.{u}} {C : Cat.{u,u+1}} :
 def baseUvPolyTpCompDomEquiv {Γ : Ctx.{u}} :
     (base.uvPolyTp.compDom base.uvPolyTp).obj (op Γ)
     ≃ (α : Ctx.toGrpd.obj Γ ⥤ PGrpd.{u,u})
-    × (β : Ctx.toGrpd.obj Γ ⥤ PGrpd.{u,u})
     × (B : Groupoidal (α ⋙ PGrpd.forgetToGrpd) ⥤ Grpd.{u,u})
+    × (β : Ctx.toGrpd.obj Γ ⥤ PGrpd.{u,u})
     ×' β ⋙ PGrpd.forgetToGrpd = Groupoidal.sec α ⋙ B :=
   yonedaEquiv.symm.trans (
   (base.uvPolyTpCompDomEquiv Γ).trans
@@ -247,9 +236,9 @@ def baseUvPolyTpCompDomEquiv {Γ : Ctx.{u}} :
     yonedaCatEquiv $
     fun α => Equiv.sigmaCongr
       yonedaCatEquiv $
-      fun β => Equiv.psigmaCongrProp
+      fun B => Equiv.psigmaCongrProp
         yonedaCatEquiv $
-        fun B => by
+        fun β => by
   convert_to _ ↔ yonedaCatEquiv (β ≫ yonedaCat.map PGrpd.forgetToGrpd)
     = Ctx.toGrpd.map (Ctx.ofGrpd.map
       (Groupoidal.sec (yonedaCatEquiv α))) ⋙ yonedaCatEquiv B
@@ -257,7 +246,6 @@ def baseUvPolyTpCompDomEquiv {Γ : Ctx.{u}} :
     yoneda.map (Ctx.ofGrpd.map (Groupoidal.sec (yonedaCatEquiv α))) ≫ B
   · simp only [yonedaCatEquiv_naturality_left, ← yonedaCatEquiv.apply_eq_iff_eq]
   simp [yonedaCatEquiv.apply_eq_iff_eq]))
-
 
 end GroupoidModel
 

--- a/GroupoidModel/Groupoids/NaturalModelBase.lean
+++ b/GroupoidModel/Groupoids/NaturalModelBase.lean
@@ -205,33 +205,29 @@ def baseUvPolyTpEquiv {Γ : Ctx.{u}} {C : Cat.{u,u+1}} :
     yonedaCatEquiv
     (fun _ => yonedaCatEquiv)))
 
--- TODO use `genPbEquiv` to define this
-/-- A specialization of the universal property of `genPb` to the natural model `base` -/
-def baseGenPbEquiv {Γ : Ctx.{u}} {C : Cat.{u,u+1}} :
-    (UvPoly.genPb base.uvPolyTp (yonedaCat.obj C)).obj (op Γ)
-    ≃ (α : Ctx.toGrpd.obj Γ ⥤ PGrpd.{u,u})
-    × (Groupoidal (α ⋙ PGrpd.forgetToGrpd) ⥤ Grpd.{u,u}) :=
-  sorry
+-- -- NOTE: maybe no need for this
+-- /-- A specialization of the universal property of `genPb` to the natural model `base` -/
+-- def baseGenPbEquiv {Γ : Ctx.{u}} {C : Cat.{u,u+1}} :
+--     (UvPoly.genPb base.uvPolyTp (yonedaCat.obj C)).obj (op Γ)
+--     ≃ (α : Ctx.toGrpd.obj Γ ⥤ PGrpd.{u,u})
+--     × (Groupoidal (α ⋙ PGrpd.forgetToGrpd) ⥤ Grpd.{u,u}) :=
+--   yonedaEquiv.symm.trans (
+--   (base.genPbEquiv Γ (yonedaCat.obj C)).trans
+--   (Equiv.sigmaCongr yonedaCatEquiv $ fun _ =>
+--     yonedaCatEquiv))
 
--- TODO move this to Grothendieck file
--- NOTE this should be defined using `IsMegaPullback`
-/-- `sec` is the universal lift in the following diagram,
-  which is a section of `Groupoidal.forget`
-             α
-  ===== Γ -------α--------------¬
- ‖      ↓ sec                   V
- ‖   M.ext A ⋯ -------------> PGrpd
- ‖      |                        |
- ‖      |                        |
- ‖   forget                  forgetToGrpd
- ‖      |                        |
- ‖      V                        V
-  ===== Γ --α ≫ forgetToGrpd--> Grpd
--/
-def _root_.CategoryTheory.Grothendieck.Groupoidal.sec {Γ : Grpd.{v₂,u₂}} (α : Γ ⥤ PGrpd.{v₁,u₁}) :
-    Γ ⥤ Groupoidal (α ⋙ PGrpd.forgetToGrpd) := sorry
+@[simp] theorem base_sec {Γ : Ctx.{u}} (α : y(Γ) ⟶ base.Tm) :
+    base.sec α = ym(Ctx.ofGrpd.map (Groupoidal.sec (yonedaCatEquiv α))) :=
+  (base.disp_pullback (α ≫ base.tp)).hom_ext
+  (by
+    rw [NaturalModelBase.sec_var]
+    dsimp only [base_var, var]
+    convert_to α =
+    yonedaCatEquiv.symm
+      (Groupoidal.sec (yonedaCatEquiv α) ⋙ Groupoidal.toPGrpd (yonedaCatEquiv α ⋙ Cat.homOf PGrpd.forgetToGrpd))
+    rw [Groupoidal.sec_toPGrpd _, yonedaCatEquiv.eq_symm_apply])
+  (by rw [NaturalModelBase.sec_disp]; rfl)
 
--- TODO define using `uvPolyTpCompDomEquiv`
 /-- A specialization of the universal property of `UvPoly.compDom`
   to the natural model `base`.
   This consists of a pair of dependent types
@@ -245,7 +241,23 @@ def baseUvPolyTpCompDomEquiv {Γ : Ctx.{u}} :
     × (β : Ctx.toGrpd.obj Γ ⥤ PGrpd.{u,u})
     × (B : Groupoidal (α ⋙ PGrpd.forgetToGrpd) ⥤ Grpd.{u,u})
     ×' β ⋙ PGrpd.forgetToGrpd = Groupoidal.sec α ⋙ B :=
-  sorry
+  yonedaEquiv.symm.trans (
+  (base.uvPolyTpCompDomEquiv Γ).trans
+  (Equiv.sigmaCongr
+    yonedaCatEquiv $
+    fun α => Equiv.sigmaCongr
+      yonedaCatEquiv $
+      fun β => Equiv.psigmaCongrProp
+        yonedaCatEquiv $
+        fun B => by
+  convert_to _ ↔ yonedaCatEquiv (β ≫ yonedaCat.map PGrpd.forgetToGrpd)
+    = Ctx.toGrpd.map (Ctx.ofGrpd.map
+      (Groupoidal.sec (yonedaCatEquiv α))) ⋙ yonedaCatEquiv B
+  convert_to _ ↔ β ≫ yonedaCat.map PGrpd.forgetToGrpd =
+    yoneda.map (Ctx.ofGrpd.map (Groupoidal.sec (yonedaCatEquiv α))) ≫ B
+  · simp only [yonedaCatEquiv_naturality_left, ← yonedaCatEquiv.apply_eq_iff_eq]
+  simp [yonedaCatEquiv.apply_eq_iff_eq]))
+
 
 end GroupoidModel
 

--- a/GroupoidModel/Russell_PER_MS/Interpretation.lean
+++ b/GroupoidModel/Russell_PER_MS/Interpretation.lean
@@ -20,7 +20,7 @@ noncomputable section
 namespace NaturalModelBase
 namespace UHomSeq
 
-variable {𝒞 : Type u} [Category.{v, u} 𝒞] [ChosenFiniteProducts 𝒞]
+variable {𝒞 : Type u} [SmallCategory 𝒞] [ChosenFiniteProducts 𝒞]
 
 /-! ## Extension sequences -/
 
@@ -29,7 +29,7 @@ where `Γ` is a prefix of `Γ'`.
 It witnesses a sequence of context extension operations in `s`
 that built `Γ'` on top of `Γ`.
 We write `Γ ≤ Γ'`. -/
-inductive ExtSeq (s : UHomSeq 𝒞) (Γ : 𝒞) : 𝒞 → Type (max u v) where
+inductive ExtSeq (s : UHomSeq 𝒞) (Γ : 𝒞) : 𝒞 → Type u where
   | nil : s.ExtSeq Γ Γ
   | snoc {Γ'} {l : Nat} (d : s.ExtSeq Γ Γ') (llen : l < s.length + 1) (A : y(Γ') ⟶ s[l].Ty) :
     s.ExtSeq Γ (s[l].ext A)
@@ -206,7 +206,7 @@ i.e., one of the form `1.Aₙ₋₁.….A₀`,
 together with the extension sequence `[Aₙ₋₁ :: … :: A₀]`.
 
 This kind of object can be destructured. -/
-def CObj (s : UHomSeq 𝒞) : Type (max u v) := Σ Γ : 𝒞, s.ExtSeq (⊤_ 𝒞) Γ
+def CObj (s : UHomSeq 𝒞) : Type u := Σ Γ : 𝒞, s.ExtSeq (⊤_ 𝒞) Γ
 
 def nilCObj (s : UHomSeq 𝒞) : s.CObj :=
   ⟨⊤_ 𝒞, .nil⟩

--- a/GroupoidModel/Russell_PER_MS/NaturalModelBase.lean
+++ b/GroupoidModel/Russell_PER_MS/NaturalModelBase.lean
@@ -23,7 +23,7 @@ structure NaturalModelBase (Ctx : Type u) [Category Ctx] where
 
 namespace NaturalModelBase
 
-variable {Ctx : Type u} [Category.{v, u} Ctx] (M : NaturalModelBase Ctx)
+variable {Ctx : Type u} [SmallCategory Ctx]  (M : NaturalModelBase Ctx)
 
 /-! ## Pullback of representable natural transformation -/
 
@@ -189,7 +189,7 @@ theorem inst_wk {Γ : Ctx} {X : Psh Ctx}
 
 /-! ## Polynomial functor on `tp` -/
 
-variable [SmallCategory Ctx] (M : NaturalModelBase Ctx)
+variable (M : NaturalModelBase Ctx)
 
 -- TODO(WN): move to ForMathlib or somewhere
 instance : HasFiniteWidePullbacks (Psh Ctx) := hasFiniteWidePullbacks_of_hasFiniteLimits _
@@ -200,7 +200,7 @@ instance {Tm Ty : Psh Ctx} (tp : Tm ⟶ Ty) : CartesianExponentiable tp where
   functor := LCC.pushforward tp
   adj := LCC.adj _
 
-def uvPolyTp : UvPoly M.Tm M.Ty := ⟨M.tp, inferInstance⟩
+@[simps] def uvPolyTp : UvPoly M.Tm M.Ty := ⟨M.tp, inferInstance⟩
 def uvPolyTpT : UvPoly.Total (Psh Ctx) := ⟨_, _, M.uvPolyTp⟩
 def Ptp : Psh Ctx ⥤ Psh Ctx := M.uvPolyTp.functor
 

--- a/GroupoidModel/Russell_PER_MS/NaturalModelSigma.lean
+++ b/GroupoidModel/Russell_PER_MS/NaturalModelSigma.lean
@@ -7,7 +7,7 @@ noncomputable section
 open CategoryTheory Limits NaturalModelBase
 
 namespace NaturalModelBase
-variable {Ctx : Type u} [Category.{v, u} Ctx] (M : NaturalModelBase Ctx)
+variable {Ctx : Type u}
   [SmallCategory Ctx] (M : NaturalModelBase Ctx)
 
 structure NaturalModelPi where
@@ -36,6 +36,7 @@ def uvPolyTpEquiv (Γ : Ctx) (X : Psh Ctx) :
   (Equiv.sigmaCongrRight (fun _ =>
     Iso.homCongr (pullbackIsoExt _ _) (Iso.refl _)))
 
+-- NOTE maybe no need for this? Try to prove `uvPolyTpCompDomEquiv` without
 /-- A specialization of the universal property of `genPb` to `M.uvPolyTp`,
   using the chosen pullback `M.ext` instead of `pullback`. -/
 def genPbEquiv (Γ : Ctx) (X : Psh Ctx) :
@@ -59,7 +60,16 @@ def genPbEquiv (Γ : Ctx) (X : Psh Ctx) :
 -/
 -- TODO(WN): move to `NaturalModel`
 def sec {Γ : Ctx} (α : y(Γ) ⟶ M.Tm) :
-    Γ ⟶ M.ext (α ≫ M.tp) := sorry
+    y(Γ) ⟶ y(M.ext (α ≫ M.tp)) :=
+  (M.disp_pullback (α ≫ M.tp)).lift α (𝟙 y(Γ)) rfl
+
+@[simp] theorem sec_var {Γ : Ctx} (α : y(Γ) ⟶ M.Tm) :
+    M.sec α ≫ M.var (α ≫ M.tp) = α :=
+  (M.disp_pullback (α ≫ M.tp)).lift_fst _ _ _
+
+@[simp] theorem sec_disp {Γ : Ctx} (α : y(Γ) ⟶ M.Tm) :
+    M.sec α ≫ ym(M.disp (α ≫ M.tp)) = 𝟙 _ :=
+  (M.disp_pullback (α ≫ M.tp)).lift_snd _ _ _
 
 /-- A specialization of the universal property of `UvPoly.compDom` to `M.uvPolyTp`,
   using the chosen pullback `M.ext` instead of `pullback`. -/
@@ -68,7 +78,7 @@ def uvPolyTpCompDomEquiv (Γ : Ctx) :
     ≃ (α : y(Γ) ⟶ M.Tm)
     × (β : y(Γ) ⟶ M.Tm)
     × (B : y(M.ext (α ≫ M.tp)) ⟶ M.Ty)
-    ×' β ≫ M.tp = ym(M.sec α) ≫ B :=
+    ×' β ≫ M.tp = M.sec α ≫ B :=
   sorry
 
 end NaturalModelBase

--- a/GroupoidModel/Russell_PER_MS/NaturalModelSigma.lean
+++ b/GroupoidModel/Russell_PER_MS/NaturalModelSigma.lean
@@ -29,21 +29,37 @@ def pullbackIsoExt {Γ : Ctx} (A : y(Γ) ⟶ M.Ty) :
   the universal property of `UvPoly` to `M.uvPolyTp`.
   We use the chosen pullback `M.ext A`
   instead of `pullback` from the `HasPullback` instance -/
-def uvPolyTpEquiv (Γ : Ctx) (X : Psh Ctx) :
+def uvPolyTpEquiv {Γ : Ctx} {X : Psh Ctx} :
     (y(Γ) ⟶ M.uvPolyTp.functor.obj X)
     ≃ (A : y(Γ) ⟶ M.Ty) × (y(M.ext A) ⟶ X) :=
   (UvPoly.equiv _ _ _).trans
   (Equiv.sigmaCongrRight (fun _ =>
     Iso.homCongr (pullbackIsoExt _ _) (Iso.refl _)))
 
--- NOTE maybe no need for this? Try to prove `uvPolyTpCompDomEquiv` without
-/-- A specialization of the universal property of `genPb` to `M.uvPolyTp`,
-  using the chosen pullback `M.ext` instead of `pullback`. -/
-def genPbEquiv (Γ : Ctx) (X : Psh Ctx) :
-    (y(Γ) ⟶ M.uvPolyTp.genPb X)
-    ≃ (α : y(Γ) ⟶ M.Tm)
-    × (y(M.ext (α ≫ M.tp)) ⟶ M.Ty) :=
-  sorry
+@[simp] theorem uvPolyTpEquiv_fst {Γ : Ctx} {X : Psh Ctx}
+    (AB : y(Γ) ⟶ M.uvPolyTp.functor.obj X) :
+    (M.uvPolyTpEquiv AB).1 = AB ≫ M.uvPolyTp.proj _ :=
+  rfl
+
+@[simp] theorem uvPolyTpEquiv_symm_snd {Γ : Ctx} {X : Psh Ctx}
+    (A : y(Γ) ⟶ M.Ty) (B : y(M.ext A) ⟶ X) :
+    eqToHom (by simp) ≫ (M.uvPolyTpEquiv (M.uvPolyTpEquiv.symm ⟨A, B⟩)).snd = B := by
+  apply eq_of_heq
+  rw [eqToHom_comp_heq_iff]
+  have h1 : M.uvPolyTpEquiv (M.uvPolyTpEquiv.symm ⟨A, B⟩) = ⟨A, B⟩ := by simp
+  exact (Sigma.mk.inj_iff.mp ((Sigma.eta _).trans h1)).2
+
+theorem uvPolyTpEquiv_symm {Γ : Ctx} {X : Psh Ctx}
+    (A : y(Γ) ⟶ M.Ty) (B : y(M.ext A) ⟶ X) :
+    M.uvPolyTpEquiv.symm ⟨ A, B ⟩ =
+    M.uvPolyTp.pairPoly A ((pullbackIsoExt _ _).hom ≫ B) :=
+  rfl
+
+@[simp] theorem uvPolyTpEquiv_symm_proj
+    {Γ : Ctx} {X : Psh Ctx} (A : y(Γ) ⟶ M.Ty) (B : y(M.ext A) ⟶ X):
+    M.uvPolyTpEquiv.symm ⟨A, B⟩ ≫ M.uvPolyTp.proj _ = A := by
+  simp only [uvPolyTpEquiv_symm]
+  apply M.uvPolyTp.pair_proj
 
 /-- `sec` is the universal lift in the following diagram,
   which is a section of `Groupoidal.forget`
@@ -71,15 +87,49 @@ def sec {Γ : Ctx} (α : y(Γ) ⟶ M.Tm) :
     M.sec α ≫ ym(M.disp (α ≫ M.tp)) = 𝟙 _ :=
   (M.disp_pullback (α ≫ M.tp)).lift_snd _ _ _
 
+theorem lift_ev {Γ : Ctx} {AB : y(Γ) ⟶ M.uvPolyTp.functor.obj M.Ty}
+    {α : y(Γ) ⟶ M.Tm} (hA : AB ≫ M.uvPolyTp.proj M.Ty = α ≫ M.tp)
+    : pullback.lift AB α hA ≫ UvPoly.genPb.u₂ M.uvPolyTp M.Ty
+    = M.sec α ≫ eqToHom (by rw [← hA]; rfl) ≫ (M.uvPolyTpEquiv AB).2 :=
+  sorry
+
 /-- A specialization of the universal property of `UvPoly.compDom` to `M.uvPolyTp`,
   using the chosen pullback `M.ext` instead of `pullback`. -/
 def uvPolyTpCompDomEquiv (Γ : Ctx) :
     (y(Γ) ⟶ M.uvPolyTp.compDom M.uvPolyTp)
     ≃ (α : y(Γ) ⟶ M.Tm)
-    × (β : y(Γ) ⟶ M.Tm)
     × (B : y(M.ext (α ≫ M.tp)) ⟶ M.Ty)
+    × (β : y(Γ) ⟶ M.Tm)
     ×' β ≫ M.tp = M.sec α ≫ B :=
-  sorry
+  calc
+    _ ≃ _ := UvPoly.compDomEquiv
+    _ ≃ _ := {
+      toFun x := match x with
+      | ⟨ AB, α, β, hA, hB ⟩ => ⟨ α,
+        ⟨ eqToHom (by dsimp only [uvPolyTp] at hA; rw [← hA]; rfl)
+        ≫ (M.uvPolyTpEquiv AB).2 , β , hB.trans (M.lift_ev hA) ⟩⟩
+      invFun x := match x with
+      | ⟨ α, B, β, h ⟩ => ⟨ M.uvPolyTpEquiv.symm ⟨ α ≫ M.tp, B ⟩, α, β, by
+        fconstructor
+        · simp [uvPolyTp_p, uvPolyTpEquiv_symm_proj]
+        · refine h.trans ?_
+          rw [M.lift_ev]
+          congr 1
+          rw [uvPolyTpEquiv_symm_snd] ⟩
+      left_inv x := match x with
+      | ⟨ AB, α, β, hA, hB ⟩ => by
+        congr!
+        dsimp only [uvPolyTpEquiv_fst]
+        rw [Equiv.symm_apply_eq]
+        refine Eq.trans ?_ (Sigma.eta _)
+        ext
+        · rw [M.uvPolyTpEquiv_fst, NatTrans.congr_app hA]
+          simp
+        · simp
+      right_inv x := match x with
+      | ⟨ α, B, β, h ⟩ => by
+        congr!
+        rw [uvPolyTpEquiv_symm_snd] }
 
 end NaturalModelBase
 end

--- a/GroupoidModel/Russell_PER_MS/UHom.lean
+++ b/GroupoidModel/Russell_PER_MS/UHom.lean
@@ -13,7 +13,7 @@ open CategoryTheory Limits Opposite MonoidalCategory
 
 namespace NaturalModelBase
 
-variable {Ctx : Type u} [Category.{v, u} Ctx]
+variable {Ctx : Type u} [SmallCategory Ctx]
 
 -- We have a 'nice', specific terminal object in `Ctx`,
 -- and this instance allows use to use it directly
@@ -125,8 +125,9 @@ def UHom.ofTarskiU (M : NaturalModelBase Ctx) (U : y(𝟙_ Ctx) ⟶ M.Ty) (El : 
       (by simp) (by simp)⟩
 }
 
+variable (Ctx) in
 /-- A sequence of Russell embeddings. -/
-structure UHomSeq (Ctx : Type u) [Category.{v, u} Ctx] [ChosenFiniteProducts Ctx] where
+structure UHomSeq [ChosenFiniteProducts Ctx] where
   /-- Number of embeddings in the sequence,
   or one less than the number of models in the sequence. -/
   length : Nat


### PR DESCRIPTION
Resolving [this issue](https://github.com/sinhp/groupoid_model_in_lean4/issues/67):

- I ended up removing some of the `gebPb` results, because that should only need to exist at the generality of `UvPoly` to define the universal property of `compDom`. 
- The general universal property of `compDom` (defined in `ForPoly`) is then used to specialise the universal property to the generality of `NaturalModelBase` i.e. taking the polynomial `M.uvPolyTp` for some natural model base `M`.
- Then we further unfold the universal property of `compDom` for the ambient groupoid model `GroupoidModel.base` using `yonedaCatEquiv`.

Along the way 
- `Ctx` was given `[Category.{v} Ctx]` and then also `[SmallCategory Ctx]` in some of the `Russell_PER_MS` files. This duplication of assumptions seems bad, so I just required `SmallCategory Ctx` for the whole file. 
- I deleted `PSigma.heq_mk_iff` because it may be unprovable.

TODO
- put some of the `ForPoly` stuff in the `Poly` repo. I know Sina is working on changing how `UvPoly.equiv` works.