### PR TITLE
Relational evaluator proof

### DIFF
--- a/GroupoidModel/Syntax/GCongr.lean
+++ b/GroupoidModel/Syntax/GCongr.lean
@@ -30,7 +30,7 @@ theorem EqTp.cong_pi_dom {Γ A A' B l l'} :
 theorem EqTp.cong_pi_cod {Γ A B B' l l'} :
     (A, l) :: Γ ⊢[l'] B ≡ B' →
     Γ ⊢[max l l'] .pi l l' A B ≡ .pi l l' A B' :=
-  fun h => EqTp.cong_pi (EqTp.refl_tp h.wf_ctx.inv_snoc) h
+  fun h => EqTp.cong_pi (EqTp.refl_tp h.wf_binder) h
 
 attribute [gcongr] EqTp.cong_sigma
 
@@ -45,7 +45,7 @@ theorem EqTp.cong_sigma_dom {Γ A A' B l l'} :
 theorem EqTp.cong_sigma_cod {Γ A B B' l l'} :
     (A, l) :: Γ ⊢[l'] B ≡ B' →
     Γ ⊢[max l l'] .sigma l l' A B ≡ .sigma l l' A B' :=
-  fun h => EqTp.cong_sigma (EqTp.refl_tp h.wf_ctx.inv_snoc) h
+  fun h => EqTp.cong_sigma (EqTp.refl_tp h.wf_binder) h
 
 attribute [gcongr] EqTp.cong_el
 
@@ -64,7 +64,7 @@ theorem EqTm.cong_lam_dom {Γ A A' B t l l'} :
 theorem EqTm.cong_lam_body {Γ A B t t' l l'} :
     (A, l) :: Γ ⊢[l'] t ≡ t' : B →
     Γ ⊢[max l l'] .lam l l' A t ≡ .lam l l' A t' : .pi l l' A B :=
-  fun htt' => EqTm.cong_lam (EqTp.refl_tp htt'.wf_ctx.inv_snoc) htt'
+  fun htt' => EqTm.cong_lam (EqTp.refl_tp htt'.wf_binder) htt'
 
 attribute [gcongr] EqTm.cong_app
 
@@ -133,7 +133,7 @@ theorem EqTm.cong_fst_cod {Γ A B B' p l l'} :
     (A, l) :: Γ ⊢[l'] B ≡ B' →
     Γ ⊢[max l l'] p : .sigma l l' A B →
     Γ ⊢[l] .fst l l' A B p ≡ .fst l l' A B' p : A :=
-  fun BB' p => .cong_fst (EqTp.refl_tp BB'.wf_ctx.inv_snoc) BB' (EqTm.refl_tm p)
+  fun BB' p => .cong_fst (EqTp.refl_tp BB'.wf_binder) BB' (EqTm.refl_tm p)
 
 @[gcongr]
 theorem EqTm.cong_fst_pair {Γ A B p p' l l'} :
@@ -141,7 +141,7 @@ theorem EqTm.cong_fst_pair {Γ A B p p' l l'} :
     Γ ⊢[l] .fst l l' A B p ≡ .fst l l' A B p' : A :=
   fun pp' =>
     have ⟨_, B⟩ := pp'.wf_tp.inv_sigma
-    .cong_fst (EqTp.refl_tp B.wf_ctx.inv_snoc) (EqTp.refl_tp B) pp'
+    .cong_fst (EqTp.refl_tp B.wf_binder) (EqTp.refl_tp B) pp'
 
 attribute [gcongr] EqTm.cong_snd
 
@@ -157,7 +157,7 @@ theorem EqTm.cong_snd_cod {Γ A B B' p l l'} :
     (A, l) :: Γ ⊢[l'] B ≡ B' →
     Γ ⊢[max l l'] p : .sigma l l' A B →
     Γ ⊢[l'] .snd l l' A B p ≡ .snd l l' A B' p : B.subst (Expr.fst l l' A B p).toSb :=
-  fun BB' p => .cong_snd (EqTp.refl_tp BB'.wf_ctx.inv_snoc) BB' (EqTm.refl_tm p)
+  fun BB' p => .cong_snd (EqTp.refl_tp BB'.wf_binder) BB' (EqTm.refl_tm p)
 
 @[gcongr]
 theorem EqTm.cong_snd_pair {Γ A B p p' l l'} :
@@ -165,7 +165,7 @@ theorem EqTm.cong_snd_pair {Γ A B p p' l l'} :
     Γ ⊢[l'] .snd l l' A B p ≡ .snd l l' A B p' : B.subst (Expr.fst l l' A B p).toSb :=
   fun pp' =>
     have ⟨_, B⟩ := pp'.wf_tp.inv_sigma
-    .cong_snd (EqTp.refl_tp B.wf_ctx.inv_snoc) (EqTp.refl_tp B) pp'
+    .cong_snd (EqTp.refl_tp B.wf_binder) (EqTp.refl_tp B) pp'
 
 /-! ## Lemmas for substitution -/
 

--- a/GroupoidModel/Syntax/Injectivity.lean
+++ b/GroupoidModel/Syntax/Injectivity.lean
@@ -29,10 +29,10 @@ private theorem strong_piInj :
     exact ⟨_, _, rfl, rfl, EqTp.symm_tp ‹_›, Beq.symm_tp.conv_ctx (Aeq.wf_ctx.eq_self.snoc Aeq)⟩
   . rename_i pi
     have := pi.inv_pi
-    exact ⟨_, _, this.1, rfl, EqTp.refl_tp this.2.wf_ctx.inv_snoc, EqTp.refl_tp this.2⟩
+    exact ⟨_, _, this.1, rfl, EqTp.refl_tp this.2.wf_binder, EqTp.refl_tp this.2⟩
   . rename_i pi
     have := pi.inv_pi
-    exact ⟨_, _, this.1, rfl, EqTp.refl_tp this.2.wf_ctx.inv_snoc, EqTp.refl_tp this.2⟩
+    exact ⟨_, _, this.1, rfl, EqTp.refl_tp this.2.wf_binder, EqTp.refl_tp this.2⟩
   . grind
   . grind
   . rename_i ih _ _ _ _ _ ih'
@@ -76,10 +76,10 @@ private theorem strong_sigmaInj :
     exact ⟨_, _, rfl, rfl, EqTp.symm_tp ‹_›, Beq.symm_tp.conv_ctx (Aeq.wf_ctx.eq_self.snoc Aeq)⟩
   . rename_i s
     have := s.inv_sigma
-    exact ⟨_, _, this.1, rfl, EqTp.refl_tp this.2.wf_ctx.inv_snoc, EqTp.refl_tp this.2⟩
+    exact ⟨_, _, this.1, rfl, EqTp.refl_tp this.2.wf_binder, EqTp.refl_tp this.2⟩
   . rename_i s
     have := s.inv_sigma
-    exact ⟨_, _, this.1, rfl, EqTp.refl_tp this.2.wf_ctx.inv_snoc, EqTp.refl_tp this.2⟩
+    exact ⟨_, _, this.1, rfl, EqTp.refl_tp this.2.wf_binder, EqTp.refl_tp this.2⟩
   . grind
   . grind
   . rename_i ih _ _ _ _ _ ih'

--- a/GroupoidModel/Syntax/Substitution.lean
+++ b/GroupoidModel/Syntax/Substitution.lean
@@ -147,6 +147,9 @@ theorem Lookup.lt_length {Γ i A l} : Lookup Γ i A l → i < Γ.length := by
 theorem Lookup.lvl_eq {Γ i A l} (lk : Lookup Γ i A l) : l = (Γ[i]'lk.lt_length).2 := by
   induction lk <;> grind
 
+theorem Lookup.tp_uniq {Γ i A A' l} (lk : Lookup Γ i A l) (lk' : Lookup Γ i A' l) : A = A' := by
+  induction lk generalizing A' <;> grind [cases Lookup]
+
 theorem Lookup.of_lt_length {Γ i} : i < Γ.length → ∃ A l, Lookup Γ i A l := by
   intro lt
   induction Γ generalizing i

--- a/GroupoidModel/Syntax/Typechecker/Evaluate.lean
+++ b/GroupoidModel/Syntax/Typechecker/Evaluate.lean
@@ -1,12 +1,7 @@
 import Qq
 
-import GroupoidModel.Syntax.GCongr
 import GroupoidModel.Syntax.Synth
-import GroupoidModel.Syntax.Injectivity
-import GroupoidModel.Syntax.Typechecker.ValueButItsARelationAndAnnotationsGone
-
-/-- Shorthand for `List.length` which is used a lot in this file. -/
-local notation "‖" l "‖" => List.length l
+import GroupoidModel.Syntax.Typechecker.Value
 
 -- /-- Hacks to use during development:
 -- `as_aux_lemma` blocks are not elaborated and kernel typechecking is off,

--- a/GroupoidModel/Syntax/Typechecker/Evaluate.lean
+++ b/GroupoidModel/Syntax/Typechecker/Evaluate.lean
@@ -175,8 +175,14 @@ partial def evalTm (Δ : Ctx) (env : List Val) (Γ : Ctx) (l : Nat) (t : Expr)
             (vaeq.conv_eq saeq.symm_tp)
       )⟩
   | .pair k k' B t u => do
-    let ⟨vt, vtpfs⟩ ← evalTm Δ env Γ k t q($Δenv) q(($Γt).inv_pair.2.2.1.with_synthTp)
-    let ⟨vu, vupfs⟩ ← evalTm Δ env Γ k' u q($Δenv) q(($Γt).inv_pair.2.2.2.1.with_synthTp)
+    let ⟨vt, vtpfs⟩ ← evalTm Δ env Γ k t q($Δenv)
+      q(by as_aux_lemma =>
+        have ⟨_, _, t, _⟩ := ($Γt).inv_pair
+        exact t.with_synthTp)
+    let ⟨vu, vupfs⟩ ← evalTm Δ env Γ k' u q($Δenv)
+      q(by as_aux_lemma =>
+        have ⟨_, _, _, u, _⟩ := ($Γt).inv_pair
+        exact u.with_synthTp)
     return ⟨.pair k k' (B.subst <| Expr.up <| sbOfEnv ‖Δ‖ env) vt vu,
       q(by as_aux_lemma =>
         have ⟨vtwf, vteq⟩ := $vtpfs

--- a/GroupoidModel/Syntax/Typechecker/Evaluate.lean
+++ b/GroupoidModel/Syntax/Typechecker/Evaluate.lean
@@ -3,7 +3,7 @@ import Qq
 import GroupoidModel.Syntax.GCongr
 import GroupoidModel.Syntax.Synth
 import GroupoidModel.Syntax.Injectivity
-import GroupoidModel.Syntax.Typechecker.Value
+import GroupoidModel.Syntax.Typechecker.ValueButItsARelationAndAnnotationsGone
 
 /-- Shorthand for `List.length` which is used a lot in this file. -/
 local notation "‖" l "‖" => List.length l
@@ -11,7 +11,7 @@ local notation "‖" l "‖" => List.length l
 -- /-- Hacks to use during development:
 -- `as_aux_lemma` blocks are not elaborated and kernel typechecking is off,
 -- speeding up interactive feedback. -/
--- FIXME: make `as_aux_lemma` or general `by` elaboration async for lower interaction latency.
+-- -- FIXME: make `as_aux_lemma` or general `by` elaboration async for lower interaction latency.
 -- macro_rules
 --   | `(tactic| as_aux_lemma => $s:tacticSeq) => `(tactic| sorry)
 -- set_option linter.unusedTactic false
@@ -28,392 +28,343 @@ mutual
 Note: Inferring implicits from `Q(...)` is pretty flaky,
 so all the arguments are explicit.
 
-Note: returning `Q(⋯ ∧ ⋯)` rather than `Q(⋯) × Q(⋯)`
-makes it easier to reuse proofs between the postconditions.
-
 Note: we use `as_aux_lemma` pervasively to minimize the size of produced proof terms. -/
 -- FIXME: by using `synthLvl`, we could also get rid of the `l` args in `eval*`.
-partial def evalTp (Δ : Ctx) (env : List Val) (Γ : Ctx) (l : Nat) (T : Expr)
-    (Δenv : Q(WfEnv $Δ $env $Γ))
+partial def evalTp (Δ : Q(Ctx)) (env : Q(List Val)) (σ : Q(Nat → Expr)) (Γ : Q(Ctx))
+    (l : Q(Nat)) (T : Q(Expr))
+    (Δenv : Q(EnvEqSb $Δ $env $σ $Γ))
     (ΓT : Q($Γ ⊢[$l] ($T))) :
-    Except String ((v : Val) ×
-      Q(WfValTp $Δ $l $v ∧
-        ($Δ ⊢[$l] ($v).toExpr ‖$Δ‖ ≡ ($T).subst (sbOfEnv ‖$Δ‖ $env)))) :=
+    Lean.MetaM ((v : Q(Val)) × Q(ValEqTp $Δ $l $v <| ($T).subst $σ)) :=
   match T with
-  | .pi l l' A B => do
-    let ⟨vA, vApfs⟩ ← evalTp Δ env Γ l A q($Δenv) q(($ΓT).inv_pi.2.wf_ctx.inv_snoc)
-    return ⟨.pi l l' vA (.mk_tp Γ A env B),
+  | ~q(.pi $l $l' $A $B) => do
+    let ⟨vA, vAeq⟩ ← evalTp Δ env σ Γ l A
+      q($Δenv)
+      q(by as_aux_lemma => exact ($ΓT).inv_pi.2.wf_binder)
+    return ⟨q(.pi $l $l' $vA (.mk_tp $Γ $A $env $B)),
       q(by as_aux_lemma =>
-        have ⟨vAwf, vAeq⟩ := $vApfs
+        simp +zetaDelta only [Expr.subst]
         obtain ⟨rfl, B⟩ := ($ΓT).inv_pi
-        constructor
-        . apply WfValTp.pi vAwf
-          exact WfClosTp.clos_tp vAeq.symm_tp $Δenv B
-        . simp only [Val.toExpr, Clos.toExpr, Expr.subst]
-          gcongr
-          exact B.subst (WfSb.up ($Δenv).wf_sbOfEnv B.wf_ctx.inv_snoc) |>.conv_ctx
-            (EqCtx.refl vAeq.wf_ctx |>.snoc vAeq.symm_tp)
+        apply ValEqTp.pi $vAeq
+        apply ClosEqTp.clos_tp $Δenv (EqTp.refl_tp ($vAeq).wf_tp) B
       )⟩
-  | .sigma l l' A B => do
-    let ⟨vA, vApfs⟩ ← evalTp Δ env Γ l A q($Δenv) q(($ΓT).inv_sigma.2.wf_ctx.inv_snoc)
-    return ⟨.sigma l l' vA (.mk_tp Γ A env B),
+  | ~q(.sigma $l $l' $A $B) => do
+    let ⟨vA, vAeq⟩ ← evalTp Δ env σ Γ l A
+      q($Δenv)
+      q(by as_aux_lemma => exact ($ΓT).inv_sigma.2.wf_binder)
+    return ⟨q(.sigma $l $l' $vA (.mk_tp $Γ $A $env $B)),
       q(by as_aux_lemma =>
-        have ⟨vAwf, vAeq⟩ := $vApfs
+        simp +zetaDelta only [Expr.subst]
         obtain ⟨rfl, B⟩ := ($ΓT).inv_sigma
-        constructor
-        . apply WfValTp.sigma vAwf
-          exact WfClosTp.clos_tp vAeq.symm_tp $Δenv B
-        . simp only [Val.toExpr, Clos.toExpr, Expr.subst]
-          gcongr
-          exact B.subst (WfSb.up ($Δenv).wf_sbOfEnv B.wf_ctx.inv_snoc) |>.conv_ctx
-            (EqCtx.refl vAeq.wf_ctx |>.snoc vAeq.symm_tp)
+        apply ValEqTp.sigma $vAeq
+        apply ClosEqTp.clos_tp $Δenv (EqTp.refl_tp ($vAeq).wf_tp) B
       )⟩
-  | .el a => do
-    let ⟨va, vapfs⟩ ← evalTm Δ env Γ (l + 1) a q($Δenv) q(($ΓT).inv_el.with_synthTp)
-    return ⟨.el va,
+  | ~q(.el $a) => do
+    let ⟨va, vaeq⟩ ← evalTm Δ env σ Γ q($l + 1) a
+      q($Δenv)
+      q(by as_aux_lemma => exact ($ΓT).inv_el.with_synthTp)
+    return ⟨q(.el $va),
       q(by as_aux_lemma =>
-        have ⟨vawf, vaeq⟩ := $vapfs
-        have := ($ΓT).inv_el.tp_eq_synthTp.symm_tp.subst ($Δenv).wf_sbOfEnv
-        simp only [Expr.subst, Val.toExpr] at this ⊢
-        exact ⟨WfValTp.el <| vawf.conv_nf this, EqTp.cong_el <| vaeq.conv_eq this⟩
+        simp +zetaDelta only [Expr.subst]
+        apply ValEqTp.el <| ($vaeq).conv_tp _
+        exact ($ΓT).inv_el.tp_eq_synthTp.symm_tp.subst ($Δenv).wf_sb
       )⟩
-  | .univ l => return ⟨.univ l,
+  | ~q(.univ $l) => return ⟨q(.univ $l),
       q(by as_aux_lemma =>
         cases ($ΓT).inv_univ
-        have Δ := ($Δenv).wf_sbOfEnv.wf_dom
-        have : $l < univMax := have := ($ΓT).le_univMax; by omega
-        simp only [Expr.subst, Val.toExpr]
-        exact ⟨WfValTp.univ Δ this, EqTp.refl_tp <| WfTp.univ Δ this⟩
+        apply ValEqTp.univ ($Δenv).wf_dom
+        have := ($ΓT).le_univMax
+        omega
       )⟩
-  | A => throw s!"{repr A} is not a type"
+  | A => throwError "{A} is not a type"
 
 /-- Evaluate a term in an environment of values. -/
-partial def evalTm (Δ : Ctx) (env : List Val) (Γ : Ctx) (l : Nat) (t : Expr)
-    (Δenv : Q(WfEnv $Δ $env $Γ))
+partial def evalTm (Δ : Q(Ctx)) (env : Q(List Val)) (σ : Q(Nat → Expr)) (Γ : Q(Ctx))
+    (l : Q(Nat)) (t : Q(Expr))
+    (Δenv : Q(EnvEqSb $Δ $env $σ $Γ))
     (Γt : Q($Γ ⊢[$l] ($t) : synthTp $Γ $t)) :
-    Except String ((v : Val) ×
-      /- Potential simplification: see docstring on `Val`. -/
-      Q(WfValTm $Δ $l $v (synthTp $Γ $t |>.subst (sbOfEnv ‖$Δ‖ $env)) ∧
-        ($Δ ⊢[$l] ($v).toExpr ‖$Δ‖ ≡ ($t).subst (sbOfEnv ‖$Δ‖ $env) :
-          (synthTp $Γ $t |>.subst (sbOfEnv ‖$Δ‖ $env))))) :=
+    Lean.MetaM ((v : Q(Val)) × Q(ValEqTm $Δ $l $v (($t).subst $σ) ((synthTp $Γ $t).subst $σ))) :=
   match t with
-  | .bvar i => do
-    return ⟨env[i]?.getD default,
+  | ~q(.bvar $i) => do
+    let v : Q(Option Val) := q($env[$i]?)
+    /- We evaluate the list access and error if a concrete element doesn't pop out.
+    We do this (instead of producing e.g. `q($env[$i]? |>.getD default)`)
+    because the evaluator may inspect the syntactic form of this value later,
+    and it being `Option.getD ..` would lead to hard-to-debug errors. -/
+    let v : Q(Option Val) ← Lean.Meta.whnf v
+    have pf : $v =Q $env[$i]? := .unsafeIntro -- FIXME: `whnfQ`?
+    let ~q(some $v') := v | throwError "expected 'some _', got{Lean.indentExpr v}"
+    return ⟨v',
       q(by as_aux_lemma =>
+        simp +zetaDelta only [Expr.subst]
         have ⟨_, lk, eq⟩ := ($Γt).inv_bvar
-        simp only [getElem?_pos, ($Δenv).lookup_lt lk, Option.getD_some, Expr.subst,
-          ($Δenv).sbOfEnv_app lk]
-        have iwf := ($Δenv).lookup_wf lk
-        have Δeq := eq.symm_tp.subst ($Δenv).wf_sbOfEnv
-        exact ⟨iwf.conv_nf Δeq, EqTm.refl_tm <| iwf.wf_toExpr.conv Δeq⟩
+        apply ValEqTm.conv_tp _ (eq.subst ($Δenv).wf_sb).symm_tp
+        . convert ($Δenv).lookup_eq lk using 1
+          -- grind -- solves this, but results in `unknown metavariable`
+          subst $v
+          rename_i h
+          have ⟨_, h⟩ := List.getElem?_eq_some_iff.mp h
+          rw [h]
       )⟩
-  | .lam k k' C b => do
-    return ⟨.lam k k' (C.subst (sbOfEnv ‖Δ‖ env)) (.mk_tm Γ C env b),
+  | ~q(.lam $k $k' $C $b) => do
+    return ⟨q(.lam $k $k' (.mk_tm $Γ $C $env $b)),
       q(by as_aux_lemma =>
-        obtain ⟨rfl, D, b, ACD⟩ := ($Γt).inv_lam
-        simp only [synthTp, Expr.subst, Val.toExpr, Clos.toExpr] at ACD ⊢
-        have Δb := (b.subst <| ($Δenv).wf_sbOfEnv.up b.wf_ctx.inv_snoc)
-        constructor
-        . obtain ⟨_, _, _, _, sbD⟩ := ACD.inv_pi
-          apply WfValTm.lam <| WfClosTm.clos_tm
-            (EqTp.refl_tp Δb.wf_ctx.inv_snoc)
-            (sbD.symm_tp.subst <| ($Δenv).wf_sbOfEnv.up b.wf_ctx.inv_snoc)
-            $Δenv
-            b
-        . apply EqTm.conv_eq (EqTm.refl_tm _) (ACD.subst ($Δenv).wf_sbOfEnv).symm_tp
-          apply WfTm.lam Δb
+        simp +zetaDelta only [Expr.subst, synthTp]
+        obtain ⟨rfl, B, b, eq⟩ := ($Γt).inv_lam
+        have C := b.wf_binder
+        apply ValEqTm.lam <| ClosEqTm.clos_tm (B := B) $Δenv _ _ b
+        . exact EqTp.refl_tp <| C.subst ($Δenv).wf_sb
+        . exact b.tp_eq_synthTp.subst (($Δenv).wf_sb.up C)
       )⟩
-  | .app k k' B f a => do
-    let ⟨vf, vfpfs⟩ ← evalTm Δ env Γ (max k k') f
+  | ~q(.app $k $k' $B $f $a) => do
+    let ⟨vf, vfeq⟩ ← evalTm Δ env σ Γ q(max $k $k') f
       q($Δenv)
       q(by as_aux_lemma =>
-        obtain ⟨_, _, f, _⟩ := ($Γt).inv_app
-        apply f.conv f.tp_eq_synthTp
+        have ⟨_, _, f, _⟩ := ($Γt).inv_app
+        exact f.with_synthTp
       )
-    let ⟨va, vapfs⟩ ← evalTm Δ env Γ k a
+    let ⟨va, vaeq⟩ ← evalTm Δ env σ Γ k a
       q($Δenv)
       q(by as_aux_lemma =>
-        obtain ⟨_, _, _, a, _⟩ := ($Γt).inv_app
-        apply a.conv a.tp_eq_synthTp
+        have ⟨_, _, _, a, _⟩ := ($Γt).inv_app
+        exact a.with_synthTp
       )
-    let ⟨v, vpfs⟩ ←
+    let ⟨v, veq⟩ ←
       evalApp Δ k k'
-        (synthTp Γ a |>.subst (sbOfEnv ‖Δ‖ env))
-        (B.subst (Expr.up (sbOfEnv ‖Δ‖ env)))
-        vf
-        va
+        q((synthTp $Γ $a).subst $σ)
+        q(($B).subst (Expr.up $σ))
+        vf va q(($f).subst $σ) q(($a).subst $σ)
         q(by as_aux_lemma =>
-          obtain ⟨_, _, f, a, eq⟩ := ($Γt).inv_app
-          have := EqTp.cong_pi a.tp_eq_synthTp (EqTp.refl_tp f.wf_tp.inv_pi.2)
-            |>.symm_tp.trans_tp f.tp_eq_synthTp
-          apply ($vfpfs).1.conv_nf (this.subst ($Δenv).wf_sbOfEnv).symm_tp
+          apply ($vfeq).conv_tp
+          have ⟨_, _, f, a, _⟩ := ($Γt).inv_app
+          have ⟨_, B⟩ := f.wf_tp.inv_pi
+          apply f.tp_eq_synthTp.subst ($Δenv).wf_sb |>.symm_tp.trans_tp _
+          simp only [Expr.subst]
+          have := a.tp_eq_synthTp.subst ($Δenv).wf_sb
+          gcongr
+          exact B.subst (($Δenv).wf_sb.up B.wf_binder)
         )
-        q(($vapfs).1)
+        q($vaeq)
     return ⟨v,
       q(by as_aux_lemma =>
-        have ⟨vfwf, vfeq⟩ := $vfpfs
-        have ⟨vawf, vaeq⟩ := $vapfs
-        have ⟨vwf, veq⟩ := $vpfs
-        obtain ⟨rfl, _, f, a, _⟩ := ($Γt).inv_app
-        simp only [synthTp, Expr.subst]
-        have BvaBa : $Δ ⊢[$l]
-            (($B).subst (Expr.up (sbOfEnv ‖$Δ‖ $env))).subst (($va).toExpr ‖$Δ‖).toSb ≡
-            (($B).subst ($a).toSb).subst (sbOfEnv ‖$Δ‖ $env) := by
-          have ΓB := f.wf_tp.inv_pi.2.conv_binder a.tp_eq_synthTp
-          have ΔB := ΓB.subst <| ($Δenv).wf_sbOfEnv.up ΓB.wf_ctx.inv_snoc
-          convert ΔB.subst_eq <| EqSb.toSb vaeq using 1; autosubst
-        constructor
-        . exact (vwf).conv_nf BvaBa
-        . apply (veq).trans_tm _ |>.conv_eq BvaBa
-          have sfeq := f.tp_eq_synthTp.subst ($Δenv).wf_sbOfEnv
-          have saeq := a.tp_eq_synthTp.subst ($Δenv).wf_sbOfEnv
-          simp only [Expr.subst] at sfeq saeq
-          have B := f.wf_tp.inv_pi.2
-          apply EqTm.cong_app
-            (EqTp.refl_tp <| B.subst <| ($Δenv).wf_sbOfEnv.up B.wf_ctx.inv_snoc)
-            (vfeq.conv_eq sfeq.symm_tp)
-            (vaeq.conv_eq saeq.symm_tp)
+        obtain ⟨rfl, _, _, _, eq⟩ := ($Γt).inv_app
+        replace eq := eq.subst ($Δenv).wf_sb
+        simp +zetaDelta only [Expr.subst] at eq ⊢
+        apply ($veq).conv_tp
+        convert eq.symm_tp using 1
+        autosubst
       )⟩
-  | .pair k k' B t u => do
-    let ⟨vt, vtpfs⟩ ← evalTm Δ env Γ k t q($Δenv)
+  | ~q(.pair $k $k' $B $t $u) => do
+    let ⟨vt, vteq⟩ ← evalTm Δ env σ Γ k t q($Δenv)
       q(by as_aux_lemma =>
         have ⟨_, _, t, _⟩ := ($Γt).inv_pair
         exact t.with_synthTp)
-    let ⟨vu, vupfs⟩ ← evalTm Δ env Γ k' u q($Δenv)
+    let ⟨vu, vueq⟩ ← evalTm Δ env σ Γ k' u q($Δenv)
       q(by as_aux_lemma =>
         have ⟨_, _, _, u, _⟩ := ($Γt).inv_pair
         exact u.with_synthTp)
-    return ⟨.pair k k' (B.subst <| Expr.up <| sbOfEnv ‖Δ‖ env) vt vu,
+    return ⟨q(.pair $k $k' $vt $vu),
       q(by as_aux_lemma =>
-        have ⟨vtwf, vteq⟩ := $vtpfs
-        have ⟨vuwf, vueq⟩ := $vupfs
-        simp only [synthTp, Expr.subst, Val.toExpr] at ($Γt) ⊢
-        obtain ⟨rfl, _, t, u, eq⟩ := ($Γt).inv_pair
-        have ⟨_, B⟩ := eq.wf_left.inv_sigma
-        have ΔB := B.subst <| ($Δenv).wf_sbOfEnv.up B.wf_ctx.inv_snoc
-        have suenv : $Δ ⊢[$k'] (synthTp $Γ $u).subst (sbOfEnv ‖$Δ‖ $env) ≡
-            (($B).subst (Expr.up (sbOfEnv ‖$Δ‖ $env)) |>.subst (($vt).toExpr ‖$Δ‖).toSb) := by
-          apply u.tp_eq_synthTp.subst ($Δenv).wf_sbOfEnv |>.symm_tp.trans_tp
-          autosubst
-          apply B.subst_eq <| ($Δenv).wf_sbOfEnv.eq_self.snoc t.with_synthTp.wf_tp (vteq).symm_tm
-        constructor
-        . apply WfValTm.pair ΔB vtwf ((vuwf).conv_nf suenv)
-        . apply EqTm.cong_pair (EqTp.refl_tp ΔB) vteq ((vueq).conv_eq suenv)
+        simp +zetaDelta only [synthTp, Expr.subst] at ($Γt) ⊢
+        obtain ⟨rfl, _, _, u, _⟩ := ($Γt).inv_pair
+        have ⟨_, B⟩ := ($Γt).wf_tp.inv_sigma
+        have := B.subst (($Δenv).wf_sb.up B.wf_binder)
+        apply ValEqTm.pair this $vteq
+        apply ($vueq).conv_tp
+        have := u.tp_eq_synthTp.subst ($Δenv).wf_sb
+        convert this.symm_tp using 1; autosubst
       )⟩
-  | .fst l l' A B p => do
-    let ⟨vp, vppfs⟩ ← evalTm Δ env Γ (max l l') p
+  | ~q(.fst $k $k' $A $B $p) => do
+    let ⟨vp, vpeq⟩ ← evalTm Δ env σ Γ q(max $k $k') p
       q($Δenv)
-      q(($Γt).inv_fst.2.1.with_synthTp)
-    let ⟨v, vpfs⟩ ←
-      evalFst Δ l l' (A.subst (sbOfEnv ‖Δ‖ env)) (B.subst (Expr.up (sbOfEnv ‖Δ‖ env))) vp
+      q(by as_aux_lemma => exact ($Γt).inv_fst.2.1.with_synthTp)
+    let ⟨v, veq⟩ ←
+      evalFst Δ k k' q(($A).subst $σ) q(($B).subst (Expr.up $σ)) vp q(($p).subst $σ)
         q(by as_aux_lemma =>
-          have ⟨_, p, eq⟩ := ($Γt).inv_fst
-          have := p.tp_eq_synthTp.subst ($Δenv).wf_sbOfEnv
-          simp only [Expr.subst] at this
-          exact ($vppfs).1.conv_nf this.symm_tp
+          apply ($vpeq).conv_tp
+          have ⟨_, p, _⟩ := ($Γt).inv_fst
+          have := p.tp_eq_synthTp.subst ($Δenv).wf_sb
+          apply this.symm_tp
         )
     return ⟨v,
       q(by as_aux_lemma =>
-        have ⟨_, vpeq⟩ := $vppfs
-        have ⟨vwf, veq⟩ := $vpfs
-        obtain ⟨rfl, p, _⟩ := ($Γt).inv_fst
-        constructor
-        . convert vwf using 1; simp [synthTp]
-        . have eq := p.tp_eq_synthTp.subst ($Δenv).wf_sbOfEnv
-          simp only [Expr.subst, synthTp] at eq ⊢
-          apply veq.trans_tm
-          gcongr
-          apply vpeq.conv_eq eq.symm_tp
+        simp +zetaDelta only [Expr.subst]
+        obtain ⟨rfl, p, eq⟩ := ($Γt).inv_fst
+        apply ($veq).conv_tp (eq.subst ($Δenv).wf_sb).symm_tp
       )⟩
-  | .snd k k' A B p => do
-    let ⟨vp, vppfs⟩ ← evalTm Δ env Γ (max k k') p
+  | ~q(.snd $k $k' $A $B $p) => do
+    let ⟨vp, vpeq⟩ ← evalTm Δ env σ Γ q(max $k $k') p
       q($Δenv)
-      q(($Γt).inv_snd.2.1.with_synthTp)
-    let ⟨v, vpfs⟩ ←
-      evalSnd Δ k k' (A.subst (sbOfEnv ‖Δ‖ env)) (B.subst (Expr.up (sbOfEnv ‖Δ‖ env))) vp
+      q(by as_aux_lemma => exact ($Γt).inv_snd.2.1.with_synthTp)
+    let ⟨v, veq⟩ ←
+      evalSnd Δ k k' q(($A).subst $σ) q(($B).subst (Expr.up $σ)) vp q(($p).subst $σ)
         q(by as_aux_lemma =>
-          have ⟨_, p, eq⟩ := ($Γt).inv_snd
-          have := p.tp_eq_synthTp.subst ($Δenv).wf_sbOfEnv
-          simp only [Expr.subst] at this
-          exact ($vppfs).1.conv_nf this.symm_tp
+          apply ($vpeq).conv_tp
+          have ⟨_, p, _⟩ := ($Γt).inv_snd
+          have := p.tp_eq_synthTp.subst ($Δenv).wf_sb
+          apply this.symm_tp
         )
     return ⟨v,
       q(by as_aux_lemma =>
-        have ⟨_, vpeq⟩ := $vppfs
-        have ⟨vwf, veq⟩ := $vpfs
-        obtain ⟨rfl, p, _⟩ := ($Γt).inv_snd
-        have B := p.wf_tp.inv_sigma.2
-        have speq := p.tp_eq_synthTp.subst ($Δenv).wf_sbOfEnv
-        simp only [synthTp, Expr.subst] at speq ⊢
-        have bigEq : $Δ ⊢[$l]
-              (($B).subst (Expr.up (sbOfEnv ‖$Δ‖ $env)) |>.subst
-                (Expr.fst $k $l
-                  (($A).subst (sbOfEnv ‖$Δ‖ $env))
-                  (($B).subst (Expr.up (sbOfEnv ‖$Δ‖ $env)))
-                  (($vp).toExpr ‖$Δ‖)).toSb) ≡
-              (($B).subst (Expr.fst $k $l $A $B $p).toSb |>.subst (sbOfEnv ‖$Δ‖ $env)) := by
-          autosubst
-          apply B.subst_eq <| ($Δenv).wf_sbOfEnv.eq_self.snoc B.wf_ctx.inv_snoc _
-          gcongr
-          convert vpeq.conv_eq speq.symm_tp using 1; autosubst
-        constructor
-        . apply vwf.conv_nf bigEq
-        . apply EqTm.conv_eq _ bigEq
-          apply veq.trans_tm
-          gcongr
-          apply vpeq.conv_eq speq.symm_tp
+        simp +zetaDelta only [Expr.subst]
+        obtain ⟨rfl, p, eq⟩ := ($Γt).inv_snd
+        apply ($veq).conv_tp
+        convert eq.subst ($Δenv).wf_sb |>.symm_tp using 1
+        autosubst
       )⟩
-  | .code A => do
-    let ⟨vA, vApfs⟩ ← evalTp Δ env Γ (l - 1) A
+  | ~q(.code $A) => do
+    let ⟨vA, vAeq⟩ ← evalTp Δ env σ Γ q($l - 1) A
       q($Δenv)
-      q(by as_aux_lemma => obtain ⟨_, rfl, h, _⟩ := ($Γt).inv_code; exact h
-      )
-    return ⟨.code vA,
+      q(by as_aux_lemma => obtain ⟨_, rfl, h, _⟩ := ($Γt).inv_code; exact h)
+    return ⟨q(.code $vA),
       q(by as_aux_lemma =>
-        have ⟨vAwf, vAeq⟩ := $vApfs
-        simp only [Val.toExpr, Expr.subst, synthTp]
-        obtain ⟨_, rfl, A, _⟩ := ($Γt).inv_code
+        simp +zetaDelta only [Expr.subst]
+        obtain ⟨l, rfl, _, Teq⟩ := ($Γt).inv_code
         have := ($Γt).le_univMax
-        cases A.lvl_eq_synthLvl
-        exact ⟨WfValTm.code (by omega) vAwf, EqTm.cong_code (by omega) vAeq⟩
+        have := Teq.subst ($Δenv).wf_sb
+        apply ValEqTm.conv_tp _ this.symm_tp
+        apply ValEqTm.code (by omega) $vAeq
       )⟩
-  | t => throw s!"{repr t} is not a term"
+  | t => throwError "{t} is not a term"
 
 -- FIXME: `A` could be replaced by `synthTp Δ a`
-partial def evalApp (Δ : Ctx) (l l' : Nat) (A B : Expr) (f a : Val)
-    (Δf : Q(WfValTm $Δ (max $l $l') $f (.pi $l $l' $A $B)))
-    (Δa : Q(WfValTm $Δ $l $a $A)) :
-    Except String ((v : Val) ×
-      Q(WfValTm $Δ $l' $v (($B).subst (($a).toExpr ‖$Δ‖).toSb) ∧
-        ($Δ ⊢[$l'] ($v).toExpr ‖$Δ‖ ≡
-          .app $l $l' $B (($f).toExpr ‖$Δ‖) (($a).toExpr ‖$Δ‖) :
-          (($B).subst (($a).toExpr ‖$Δ‖).toSb)))) :=
-  match f with
-  | .lam m m' _ (.mk_tm Γ A' env b) => do
-    let ⟨v, vpfs⟩ ← evalTm Δ (a :: env) ((A', m) :: Γ) m' b
+partial def evalApp (Δ : Q(Ctx)) (l l' : Q(Nat)) (A B : Q(Expr))
+    (vf va : Q(Val)) (f a : Q(Expr))
+    (Δf : Q(ValEqTm $Δ (max $l $l') $vf $f (.pi $l $l' $A $B)))
+    (Δa : Q(ValEqTm $Δ $l $va $a $A)) :
+    Lean.MetaM ((v : Q(Val)) ×
+      Q(ValEqTm $Δ $l' $v (.app $l $l' $B $f $a) (($B).subst ($a).toSb))) :=
+  match vf with
+  | ~q(.lam $k $k' (.mk_tm $Γ $A' $env $b)) => do
+    /- To evaluate the closure in its environment `env`,
+    we need to provide a substitution `σ` with `EnvEqSb Δ env σ Γ`;
+    but such a substitution is difficult to construct
+    because `Val`s do not contain type annotations whereas `Expr`s do
+    (see now-removed `sbOfEnv`).
+    We also cannot store it in `Clos.mk_tm`
+    because that would make weakening non-free on values.
+    Instead, we obtain one using AC;
+    the choice is unique (up to `EqSb`)
+    since `EnvEqSb` is functional. -/
+    let ex : Q(∃ σ, EnvEqSb $Δ $env σ $Γ) :=
       q(by as_aux_lemma =>
-        have ⟨_, B, b, eq⟩ := ($Δf).inv_lam
-        rcases b with ⟨A'env, _, env, b⟩
-        obtain ⟨_, rfl, rfl, Aeq, _⟩ := eq.inv_pi
-        apply env.snoc b.wf_ctx.inv_snoc (($Δa).conv_nf <| Aeq.trans_tp A'env.symm_tp)
+        have ⟨_, _, _, _, c, _⟩ := ($Δf).inv_lam
+        rcases c with ⟨env, _⟩
+        exact ⟨_, env⟩
+      )
+    let ⟨v, veq⟩ ← evalTm Δ q($va :: $env)
+      q(Expr.snoc (Classical.choose $ex) $a) q(($A', $k) :: $Γ) k' b
+      q(by as_aux_lemma =>
+        have ⟨_, _, _, _, c, eqt, eq⟩ := ($Δf).inv_lam
+        rcases c with ⟨env, Aeq', _, b⟩
+        obtain ⟨_, rfl, rfl, Aeq, Beq⟩ := eq.inv_pi
+        have A' := b.wf_binder
+        apply EnvEqSb.snoc (Classical.choose_spec $ex) A'
+        apply ($Δa).conv_tp <| Aeq.trans_tp <| Aeq'.symm_tp.trans_tp <| A'.subst_eq _
+        exact env.sb_uniq (Classical.choose_spec $ex)
       )
       q(by as_aux_lemma =>
-        have ⟨_, B, b, eq⟩ := ($Δf).inv_lam
-        rcases b with ⟨A'env, _, env, b⟩
+        have ⟨_, _, _, _, c, eqt, eq⟩ := ($Δf).inv_lam
+        rcases c with ⟨_, _, _, b⟩
         exact b.with_synthTp
       )
     return ⟨v,
       q(by as_aux_lemma =>
-        have ⟨vwf, veq⟩ := $vpfs
-        have ⟨_, B, b, eq⟩ := ($Δf).inv_lam
-        rcases b with ⟨A'env, Benv, env, b⟩
+        have ⟨_, _, _, _, c, eqt, eq⟩ := ($Δf).inv_lam
+        rcases c with ⟨env, Aeq', Beq', b⟩
         obtain ⟨_, rfl, rfl, Aeq, Beq⟩ := eq.inv_pi
-        have bigEq : $Δ ⊢[$l'] (synthTp (($A', $l) :: $Γ) $b).subst (sbOfEnv ‖$Δ‖ ($a :: $env)) ≡
-            ($B).subst (Val.toExpr ‖$Δ‖ $a).toSb := by
-          have := b.tp_eq_synthTp.symm_tp.subst (env.wf_sbOfEnv.up b.wf_ctx.inv_snoc)
-            |>.conv_binder (A'env.trans_tp Aeq.symm_tp)
-            |>.trans_tp (Benv.conv_binder Aeq.symm_tp)
-            |>.trans_tp Beq.symm_tp
-          convert this.subst <| WfSb.toSb ($Δa).wf_toExpr using 1
-          autosubst
-          apply sb_irrel.1 b.with_synthTp.wf_tp
-          intro i lt
-          cases i
-          . simp
-          . dsimp; apply sbOfEnv_get_eq; simpa [env.eq_length] using lt
-        constructor
-        . apply vwf.conv_nf bigEq
-        . apply veq.conv_eq bigEq |>.trans_tm
-          have Δb := b.subst (env.wf_sbOfEnv.up b.wf_ctx.inv_snoc)
-            |>.conv_binder A'env |>.conv (Benv.trans_tp <| Beq.symm_tp.conv_binder Aeq)
-          have Δa := ($Δa).conv_nf Aeq
-          simp only [Val.toExpr, Clos.toExpr]
-          convert EqTm.app_lam Δb Δa.wf_toExpr |>.symm_tm.trans_tm _ using 1
-          . autosubst
-            apply sb_irrel.2 b
-            intro i lt
-            cases i
-            . simp
-            . dsimp; apply sbOfEnv_get_eq; simpa [env.eq_length] using lt
-          apply EqTm.refl_tm <| WfTm.app (WfTm.lam Δb) Δa.wf_toExpr
-      )⟩
-  | .neut n => do
-    let n : Val := .neut <| .app l l' B n a
-    return ⟨n,
-      q(by as_aux_lemma =>
-        constructor
-        . exact WfValTm.neut_tm <| WfNeutTm.app ($Δf).inv_neut ($Δa)
-        . simp +zetaDelta only [Val.toExpr, Neut.toExpr]
-          exact EqTm.refl_tm <| WfTm.app ($Δf).inv_neut.wf_toExpr ($Δa).wf_toExpr
-      )⟩
-  | _ => throw s!"unexpected normal form {repr f} at type Π"
+        clear eq
+        have sbeq := env.sb_uniq (Classical.choose_spec $ex)
 
-partial def evalFst (Δ : Ctx) (l l' : Nat) (A B : Expr) (p : Val)
-    (Δp : Q(WfValTm $Δ (max $l $l') $p (.sigma $l $l' $A $B))) :
-    Except String ((v : Val) ×
-      Q(WfValTm $Δ $l $v $A ∧
-        ($Δ ⊢[$l] ($v).toExpr ‖$Δ‖ ≡ .fst $l $l' $A $B (($p).toExpr ‖$Δ‖) : $A))) :=
-  match p with
-  | .pair _ _ _ v _ =>
+        replace sbeq := sbeq.snoc b.wf_binder <| EqTm.refl_tm <| ($Δa).wf_tm.conv <|
+          Aeq.trans_tp Aeq'.symm_tp
+        have := b.tp_eq_synthTp.subst_eq sbeq
+        replace ($veq) := ($veq).conv_nf ((b.subst_eq sbeq).conv_eq this).symm_tm this.symm_tp
+        replace Beq' := Beq'.conv_binder Aeq.symm_tp
+        have := Beq'.trans_tp Beq.symm_tp |>.subst (WfSb.toSb ($Δa).wf_tm)
+        simp only [autosubst] at ($veq) this ⊢
+        apply ($veq).conv_nf _ this
+        apply EqTm.conv_eq _ this.symm_tp
+        replace b := b.subst (env.wf_sb.up b.wf_binder)
+          |>.conv_binder (Aeq'.trans_tp Aeq.symm_tp)
+          |>.conv (Beq'.trans_tp Beq.symm_tp)
+        have := EqTm.app_lam b ($Δa).wf_tm |>.symm_tm
+        simp only [autosubst] at this
+        apply this.trans_tm
+        apply EqTm.cong_app (EqTp.refl_tp Beq.wf_left) _ (EqTm.refl_tm ($Δa).wf_tm)
+        apply EqTm.trans_tm _ eqt.symm_tm
+        gcongr
+        autosubst
+        convert EqTm.refl_tm b using 1 <;> autosubst
+      )⟩
+  | ~q(.neut $n) => do
+    let na : Q(Val) := q(.neut <| .app $l $l' $n $va)
+    return ⟨na,
+      q(by as_aux_lemma =>
+        exact ValEqTm.neut_tm <| NeutEqTm.app ($Δf).inv_neut $Δa
+      )⟩
+  | _ => throwError "unexpected normal form {f} at type Π"
+
+partial def evalFst (Δ : Q(Ctx)) (l l' : Q(Nat)) (A B : Q(Expr))
+    (vp : Q(Val)) (p : Q(Expr))
+    (Δp : Q(ValEqTm $Δ (max $l $l') $vp $p (.sigma $l $l' $A $B))) :
+    Lean.MetaM ((v : Q(Val)) × Q(ValEqTm $Δ $l $v (.fst $l $l' $A $B $p) $A)) :=
+  match vp with
+  | ~q(.pair _ _ $v _) =>
     return ⟨v,
       q(by as_aux_lemma =>
-        simp only [Val.toExpr]
-        have ⟨_, _, v, w, eq⟩ := ($Δp).inv_pair
+        have ⟨_, A', B', f, s, v, _, eqt, eq⟩ := ($Δp).inv_pair
         obtain ⟨_, rfl, rfl, Aeq, Beq⟩ := eq.inv_sigma
-        replace v := v.conv_nf Aeq.symm_tp
-        refine ⟨v, ?_⟩
-        apply EqTm.fst_pair Beq.wf_right v.wf_toExpr w.wf_toExpr |>.symm_tm.trans_tm
-        gcongr
-        apply WfTm.pair Beq.wf_right v.wf_toExpr w.wf_toExpr
+        have : $Δ ⊢[$l] f ≡ Expr.fst $l $l' $A $B $p : $A := by
+          have ⟨_, A'', t, u, eq'⟩ := eqt.wf_right.inv_pair
+          have ⟨_, _, _, Aeq', Beq'⟩ := eq'.inv_sigma
+          replace t := t.conv Aeq'.symm_tp
+          replace u := u.conv <| Beq'.symm_tp.subst (WfSb.toSb t)
+          apply EqTm.fst_pair Beq.wf_left t u |>.symm_tm.trans_tm
+          gcongr
+          apply EqTm.trans_tm _ eqt.symm_tm
+          gcongr <;> assumption
+        apply v.conv_nf (this.conv_eq Aeq) Aeq.symm_tp
       )⟩
-  | .neut n =>
-    return ⟨.neut (.fst l l' A B n),
+  | ~q(.neut $n) =>
+    return ⟨q(.neut (.fst $l $l' $n)),
       q(by as_aux_lemma =>
-        constructor
-        . exact WfValTm.neut_tm <| WfNeutTm.fst ($Δp).inv_neut
-        . convert EqTm.refl_tm <| WfTm.fst ($Δp).wf_toExpr using 1
-          simp [Val.toExpr, Neut.toExpr]
+        exact ValEqTm.neut_tm <| NeutEqTm.fst ($Δp).inv_neut
       )⟩
-  | _ => throw s!"unexpected normal form {repr p} at type Σ"
+  | _ => throwError "unexpected normal form {p} at type Σ"
 
-partial def evalSnd (Δ : Ctx) (l l' : Nat) (A B : Expr) (p : Val)
-    (Δp : Q(WfValTm $Δ (max $l $l') $p (.sigma $l $l' $A $B))) :
-    Except String ((v : Val) ×
-      Q(WfValTm $Δ $l' $v (($B).subst (Expr.fst $l $l' $A $B (($p).toExpr ‖$Δ‖)).toSb) ∧
-        ($Δ ⊢[$l'] ($v).toExpr ‖$Δ‖ ≡ .snd $l $l' $A $B (($p).toExpr ‖$Δ‖) :
-          ($B).subst (Expr.fst $l $l' $A $B (($p).toExpr ‖$Δ‖)).toSb))) :=
-  match p with
-  | .pair _ _ B' v w =>
+partial def evalSnd (Δ : Q(Ctx)) (l l' : Q(Nat)) (A B : Q(Expr))
+    (vp : Q(Val)) (p : Q(Expr))
+    (Δp : Q(ValEqTm $Δ (max $l $l') $vp $p (.sigma $l $l' $A $B))) :
+    Lean.MetaM ((v : Q(Val)) ×
+      Q(ValEqTm $Δ $l' $v (.snd $l $l' $A $B $p) <| ($B).subst (Expr.fst $l $l' $A $B $p).toSb)) :=
+  match vp with
+  | ~q(.pair _ _ _ $w) =>
     return ⟨w,
       q(by as_aux_lemma =>
-        simp only [Val.toExpr]
-        have ⟨_, _, v, w, eq⟩ := ($Δp).inv_pair
-        obtain ⟨_, rfl, rfl, Aeq,Beq⟩ := eq.inv_sigma
-        replace v := v.conv_nf Aeq.symm_tp
-        have fstPair : $Δ ⊢[$l]
-            (Expr.fst $l $l' $A $B (Expr.pair $l $l' $B' (($v).toExpr ‖$Δ‖) (($w).toExpr ‖$Δ‖))) ≡
-              (($v).toExpr ‖$Δ‖) : $A := by
-          apply EqTm.trans_tm _ <| EqTm.fst_pair Beq.wf_right v.wf_toExpr w.wf_toExpr
+        have ⟨_, A', B', f, s, _, w, eqt, eq⟩ := ($Δp).inv_pair
+        obtain ⟨_, rfl, rfl, Aeq, Beq⟩ := eq.inv_sigma
+        have ⟨_, A'', t, u, eq'⟩ := eqt.wf_right.inv_pair
+        have ⟨_, _, _, Aeq', Beq'⟩ := eq'.inv_sigma
+        replace t := t.conv Aeq'.symm_tp
+        replace u := u.conv <| Beq'.symm_tp.subst (WfSb.toSb t)
+        have feq : $Δ ⊢[$l] f ≡ Expr.fst $l $l' $A $B $p : $A := by
+          apply EqTm.fst_pair Beq.wf_left t u |>.symm_tm.trans_tm
           gcongr
-          apply WfTm.pair Beq.wf_right v.wf_toExpr w.wf_toExpr |>.conv
-          gcongr
-        have BFstPair := Beq.symm_tp.subst_eq <| EqSb.toSb fstPair.symm_tm
-        constructor
-        . apply w.conv_nf BFstPair
-        . have := EqTm.snd_pair Beq.wf_right v.wf_toExpr w.wf_toExpr |>.symm_tm
-          apply this.conv_eq BFstPair |>.trans_tm
-          symm; gcongr
-          apply WfTm.pair Beq.wf_right v.wf_toExpr w.wf_toExpr |>.conv
-          gcongr
+          apply EqTm.trans_tm _ eqt.symm_tm
+          gcongr <;> assumption
+        replace w := w.conv_tp <| Beq.symm_tp.subst_eq (EqSb.toSb feq)
+        apply w.conv_nf _ (EqTp.refl_tp w.wf_tm.wf_tp)
+        apply EqTm.snd_pair Beq.wf_left t u |>.symm_tm.conv_eq
+          (Beq'.wf_left.subst_eq (EqSb.toSb feq)) |>.trans_tm _
+        symm; gcongr
+        apply eqt.trans_tm
+        symm; gcongr <;> assumption
       )⟩
-  | .neut n =>
-    return ⟨.neut (.snd l l' A B n),
+  | ~q(.neut $n) =>
+    return ⟨q(.neut (.snd $l $l' $n)),
       q(by as_aux_lemma =>
-        simp only [Val.toExpr, Neut.toExpr]
-        constructor
-        . exact WfValTm.neut_tm <| WfNeutTm.snd ($Δp).inv_neut
-        . convert EqTm.refl_tm <| WfTm.snd ($Δp).wf_toExpr using 1 <;> simp [Val.toExpr]
+        exact ValEqTm.neut_tm <| NeutEqTm.snd ($Δp).inv_neut
       )⟩
-  | _ => throw s!"unexpected normal form {repr p} at type Σ"
+  | _ => throwError "unexpected normal form {p} at type Σ"
 
 end

--- a/GroupoidModel/Syntax/Typechecker/Value.lean
+++ b/GroupoidModel/Syntax/Typechecker/Value.lean
@@ -1,5 +1,5 @@
+import GroupoidModel.Syntax.GCongr
 import GroupoidModel.Syntax.Injectivity
-import GroupoidModel.Syntax.SubstList
 
 /-! # Values, neutral forms, closures, and evaluation environments
 
@@ -11,6 +11,10 @@ We relate them to the core syntax with `Val.toExpr/Neut.toExpr/Clos.toExpr/sbOfE
 
 /-- Shorthand for `List.length` which is used a lot in this file. -/
 local notation "‖" l "‖" => List.length l
+
+attribute [local grind]
+  EqTp.refl_tp EqTp.symm_tp EqTp.trans_tp
+  EqTm.refl_tm EqTm.symm_tm EqTm.trans_tm
 
 mutual
 /-- Values are produced by the evaluator during NbE.
@@ -57,8 +61,8 @@ because readback is typed, so will have sufficient typing data available. -/
 inductive Val where
   | pi (l l' : Nat) (A : Val) (B : Clos)
   | sigma (l l' : Nat) (A : Val) (B : Clos)
-  | lam (l l' : Nat) (A : Expr) (b : Clos)
-  | pair (l l' : Nat) (B : Expr) (t u : Val)
+  | lam (l l' : Nat) (b : Clos)
+  | pair (l l' : Nat) (t u : Val)
   | univ (l : Nat)
   /- TODO: to make the theory usable,
   we'll need to treat `code` and `el` as eliminators,
@@ -68,17 +72,17 @@ inductive Val where
   | code (A : Val)
   /-- A neutral form. -/
   | neut (n : Neut)
-  deriving Inhabited, Repr, Lean.ToExpr
+  deriving Inhabited
 
 /-- Neutral forms are elimination forms that are 'stuck',
 i.e., contain no β-reducible subterm. -/
 inductive Neut where
   /-- A de Bruijn *level*. -/
   | bvar (i : Nat)
-  | app (l l' : Nat) (B : Expr) (f : Neut) (a : Val)
-  | fst (l l' : Nat) (A B : Expr) (p : Neut)
-  | snd (l l' : Nat) (A B : Expr) (p : Neut)
-  deriving Lean.ToExpr
+  | app (l l' : Nat) (f : Neut) (a : Val)
+  | fst (l l' : Nat) (p : Neut)
+  | snd (l l' : Nat) (p : Neut)
+  deriving Inhabited
 
 /-- Recall that given `Γ.A ⊢ b : B` and a substitution `Δ ⊢ env : Γ`,
 `Δ.A ⊢ b[(env∘↑).v₀] : B[(env∘↑).v₀]`.
@@ -94,369 +98,290 @@ the present variant is a defunctionalization due to Abel. -/
 inductive Clos where
   | mk_tp (Γ : Ctx) (A : Expr) (env : List Val) (B : Expr)
   | mk_tm (Γ : Ctx) (A : Expr) (env : List Val) (b : Expr)
-  deriving Lean.ToExpr
+  deriving Inhabited
 end
 
-/-! ## Values as expressions -/
+/-! ## Relation of values to terms -/
 
 mutual
-variable (d : Nat)
-/-- The expression corresponding to a value well-typed in a context of length `d`. -/
-def Val.toExpr : Val → Expr
-  | .pi l l' A B => .pi l l' A.toExpr B.toExpr
-  | .sigma l l' A B => .sigma l l' A.toExpr B.toExpr
-  | .lam l l' A b => .lam l l' A b.toExpr
-  | .pair l l' B t u => .pair l l' B t.toExpr u.toExpr
-  | .univ l => .univ l
-  | .el a => .el a.toExpr
-  | .code A => .code A.toExpr
-  | .neut n => n.toExpr
-  termination_by v => sizeOf v
-
-/-- The expression corresponding to a neutral form well-typed in a context of length `d`. -/
-def Neut.toExpr : Neut → Expr
-  | .bvar l => .bvar (d - l - 1)
-  | .app l l' B f a => .app l l' B f.toExpr a.toExpr
-  | .fst l l' A B p => .fst l l' A B p.toExpr
-  | .snd l l' A B p => .snd l l' A B p.toExpr
-  termination_by n => sizeOf n
-
-/-- The expression corresponding to a closure
-whose _domain_ is a context of length `d`
-(i.e., `Δ ⊢ env : Γ` where `‖Δ‖ = d`).
-
-Remark: closures are the only kind of value
-that is not fully described by its `Expr` embedding.
-More precisely, the well-typedness of `C.toExpr`
-does not imply that `C` is well-formed.
-This is the only reason why we need `WfVal/…` judgments. -/
-def Clos.toExpr : Clos → Expr
-  | .mk_tp _ _ env B => B.subst (Expr.up <| sbOfEnv env)
-  | .mk_tm _ _ env b => b.subst (Expr.up <| sbOfEnv env)
-  termination_by c => sizeOf c
-
-/-- The substitution corresponding to an evaluation environment
-whose _domain_ is a context of length `d`
-(i.e., `Δ ⊢ env : Γ` where `‖Δ‖ = d`).
-
-See also `sbOfTms`. -/
-def sbOfEnv (env : List Val) (k := 0) : Nat → Expr :=
-  sbOfTms (env.map (·.toExpr)) k
-  termination_by sizeOf env
-end
-
-/-! ## Substitutions from environments -/
-
-@[autosubst]
-theorem sbOfEnv_nil (d) : sbOfEnv d [] = Expr.bvar := by
-  simp [sbOfEnv, autosubst]
-
-@[autosubst]
-theorem sbOfEnv_cons (d t ts k) :
-    sbOfEnv d (t :: ts) k = Expr.snoc (sbOfEnv d ts (k + 1)) (t.toExpr d) := by
-  simp [sbOfEnv, autosubst]
-
-theorem sbOfEnv_get_eq {d ts k i} : i < ts.length → sbOfEnv d ts k i = sbOfEnv d ts 0 i := by
-  intro h
-  unfold sbOfEnv
-  apply sbOfTms_get_eq
-  simp [h]
-
-theorem WfTp.sbOfEnv_irrel {Γ l A ts} (wf : Γ ⊢[l] A) (le : ‖Γ‖ ≤ ‖ts‖) (d k) :
-    A.subst (sbOfEnv d ts k) = A.subst (sbOfEnv d ts 0) := by
-  simp [sbOfEnv, wf.sbOfTms_irrel, le]
-
-theorem WfTm.sbOfEnv_irrel {Γ l A t ts} (wf : Γ ⊢[l] t : A) (le : ‖Γ‖ ≤ ‖ts‖) (d k) :
-     t.subst (sbOfEnv d ts k) = t.subst (sbOfEnv d ts 0) := by
-  simp [sbOfEnv, wf.sbOfTms_irrel, le]
-
-/-! ## Well-formed values -/
-
-mutual
-inductive WfValTp : Ctx → Nat → Val → Prop
-  | pi {Γ A B l l'} :
-    WfValTp Γ l A →
-    WfClosTp Γ l l' (A.toExpr ‖Γ‖) B →
-    WfValTp Γ (max l l') (.pi l l' A B)
-  | sigma {Γ A B l l'} :
-    WfValTp Γ l A →
-    WfClosTp Γ l l' (A.toExpr ‖Γ‖) B →
-    WfValTp Γ (max l l') (.sigma l l' A B)
+inductive ValEqTp : Ctx → Nat → Val → Expr → Prop
+  | pi {Γ vA A vB B l l'} :
+    ValEqTp Γ l vA A →
+    ClosEqTp Γ l l' A vB B →
+    ValEqTp Γ (max l l') (.pi l l' vA vB) (.pi l l' A B)
+  | sigma {Γ vA A vB B l l'} :
+    ValEqTp Γ l vA A →
+    ClosEqTp Γ l l' A vB B →
+    ValEqTp Γ (max l l') (.sigma l l' vA vB) (.sigma l l' A B)
   | univ {Γ l} :
     WfCtx Γ →
     l < univMax →
-    WfValTp Γ (l + 1) (.univ l)
-  | el {Γ a l} :
-    WfValTm Γ (l + 1) a (.univ l) →
-    WfValTp Γ l (.el a)
+    ValEqTp Γ (l + 1) (.univ l) (.univ l)
+  | el {Γ va a l} :
+    ValEqTm Γ (l + 1) va a (.univ l) →
+    ValEqTp Γ l (.el va) (.el a)
+  | conv_tp {Γ vA A A' l} :
+    ValEqTp Γ l vA A →
+    Γ ⊢[l] A ≡ A' →
+    ValEqTp Γ l vA A'
 
 -- Note: no neutral types atm.
 
-inductive WfValTm : Ctx → Nat → Val → Expr → Prop
-  | lam {Γ A B b l l'} :
-    WfClosTm Γ l l' A B b →
-    WfValTm Γ (max l l') (.lam l l' A b) (.pi l l' A B)
-  | pair {Γ A B t u l l'} :
+inductive ValEqTm : Ctx → Nat → Val → Expr → Expr → Prop
+  | lam {Γ A B vb b l l'} :
+    ClosEqTm Γ l l' A B vb b →
+    ValEqTm Γ (max l l') (.lam l l' vb) (.lam l l' A b) (.pi l l' A B)
+  | pair {Γ A B vt t vu u l l'} :
     (A, l) :: Γ ⊢[l'] B →
-    WfValTm Γ l t A →
-    WfValTm Γ l' u (B.subst (t.toExpr ‖Γ‖).toSb) →
-    WfValTm Γ (max l l') (.pair l l' B t u) (.sigma l l' A B)
-  | code {Γ A l} :
+    ValEqTm Γ l vt t A →
+    ValEqTm Γ l' vu u (B.subst t.toSb) →
+    ValEqTm Γ (max l l') (.pair l l' vt vu) (.pair l l' B t u) (.sigma l l' A B)
+  | code {Γ vA A l} :
     l < univMax →
-    WfValTp Γ l A →
-    WfValTm Γ (l + 1) (.code A) (.univ l)
-  | neut_tm {Γ A n l} :
-    WfNeutTm Γ l n A →
-    WfValTm Γ l (.neut n) A
-  | conv_nf {Γ A A' v l} :
-    WfValTm Γ l v A →
+    ValEqTp Γ l vA A →
+    ValEqTm Γ (l + 1) (.code vA) (.code A) (.univ l)
+  | neut_tm {Γ A vn n l} :
+    NeutEqTm Γ l vn n A →
+    ValEqTm Γ l (.neut vn) n A
+  | conv_nf {Γ A A' vt t t' l} :
+    ValEqTm Γ l vt t A →
+    Γ ⊢[l] t ≡ t' : A →
     Γ ⊢[l] A ≡ A' →
-    WfValTm Γ l v A'
+    ValEqTm Γ l vt t' A'
 
-inductive WfNeutTm : Ctx → Nat → Neut → Expr → Prop
+inductive NeutEqTm : Ctx → Nat → Neut → Expr → Expr → Prop
   | bvar {Γ A i l} :
     WfCtx Γ →
     Lookup Γ i A l →
-    WfNeutTm Γ l (.bvar (‖Γ‖ - i - 1)) A
-  | app {Γ A B f a l l'} :
-    WfNeutTm Γ (max l l') f (.pi l l' A B) →
-    WfValTm Γ l a A →
-    WfNeutTm Γ l' (.app l l' B f a) (B.subst (a.toExpr ‖Γ‖).toSb)
-  | fst {Γ A B p l l'} :
-    WfNeutTm Γ (max l l') p (.sigma l l' A B) →
-    WfNeutTm Γ l (.fst l l' A B p) A
-  | snd {Γ A B p l l'} :
-    WfNeutTm Γ (max l l') p (.sigma l l' A B) →
-    WfNeutTm Γ l' (.snd l l' A B p) (B.subst (Expr.fst l l' A B (p.toExpr ‖Γ‖)).toSb)
-  | conv_neut {Γ A A' n l} :
-    WfNeutTm Γ l n A →
+    NeutEqTm Γ l (.bvar (‖Γ‖ - i - 1)) (.bvar i) A
+  | app {Γ A B vf f va a l l'} :
+    NeutEqTm Γ (max l l') vf f (.pi l l' A B) →
+    ValEqTm Γ l va a A →
+    NeutEqTm Γ l' (.app l l' vf va) (.app l l' B f a) (B.subst a.toSb)
+  | fst {Γ A B vp p l l'} :
+    NeutEqTm Γ (max l l') vp p (.sigma l l' A B) →
+    NeutEqTm Γ l (.fst l l' vp) (.fst l l' A B p) A
+  | snd {Γ A B vp p l l'} :
+    NeutEqTm Γ (max l l') vp p (.sigma l l' A B) →
+    NeutEqTm Γ l' (.snd l l' vp) (.snd l l' A B p) (B.subst (Expr.fst l l' A B p).toSb)
+  | conv_neut {Γ A A' vn n n' l} :
+    NeutEqTm Γ l vn n A →
+    Γ ⊢[l] n ≡ n' : A →
     Γ ⊢[l] A ≡ A' →
-    WfNeutTm Γ l n A'
+    NeutEqTm Γ l vn n' A'
 
-/-- `WfClosTp Δ l l' A B` -/
-inductive WfClosTp : Ctx → Nat → Nat → Expr → Clos → Prop
-  | clos_tp {Δ Γ A B Aenv env l l'} :
+/-- `ClosEqTp Δ l l' A vB B` -/
+inductive ClosEqTp : Ctx → Nat → Nat → Expr → Clos → Expr → Prop
+  | clos_tp {Δ Γ A B Aenv env σ l l'} :
+    EnvEqSb Δ env σ Γ →
     -- The equality argument builds in conversion.
-    Δ ⊢[l] A.subst (sbOfEnv ‖Δ‖ env) ≡ Aenv →
-    WfEnv Δ env Γ →
+    Δ ⊢[l] A.subst σ ≡ Aenv →
     (A, l) :: Γ ⊢[l'] B →
-    WfClosTp Δ l l' Aenv (.mk_tp Γ A env B)
+    ClosEqTp Δ l l' Aenv (.mk_tp Γ A env B) (B.subst <| Expr.up σ)
 
-/-- `WfClosTm Δ l l' A B b` -/
-inductive WfClosTm : Ctx → Nat → Nat → Expr → Expr → Clos → Prop
-  | clos_tm {Δ Γ A B Aenv Benv b env l l'} :
-    Δ ⊢[l] A.subst (sbOfEnv ‖Δ‖ env) ≡ Aenv →
-    (Aenv, l) :: Δ ⊢[l'] (B.subst <| Expr.up (sbOfEnv ‖Δ‖ env)) ≡ Benv →
-    WfEnv Δ env Γ →
+/-- `ClosEqTm Δ l l' A B vb b` -/
+inductive ClosEqTm : Ctx → Nat → Nat → Expr → Expr → Clos → Expr → Prop
+  | clos_tm {Δ Γ A B Aenv Benv b env σ l l'} :
+    EnvEqSb Δ env σ Γ →
+    Δ ⊢[l] A.subst σ ≡ Aenv →
+    (Aenv, l) :: Δ ⊢[l'] (B.subst <| Expr.up σ) ≡ Benv →
     (A, l) :: Γ ⊢[l'] b : B →
-    WfClosTm Δ l l' Aenv Benv (.mk_tm Γ A env b)
+    ClosEqTm Δ l l' Aenv Benv (.mk_tm Γ A env b) (b.subst <| Expr.up σ)
 
-inductive WfEnv : Ctx → List Val → Ctx → Prop
-  /- Possible optimization: allow `WfEnv Γ [] Γ`
+inductive EnvEqSb : Ctx → List Val → (Nat → Expr) → Ctx → Prop
+  /- Possible optimization: allow `EnvEqSb Γ [] Expr.bvar Γ`
   and replace `envOfLen ‖Γ‖` by `[]`. -/
-  | nil {Γ} : WfCtx Γ → WfEnv Γ [] []
-  | snoc {Δ Γ A v E l} :
-    WfEnv Δ E Γ →
+  | nil {Γ} (σ) : WfCtx Γ → EnvEqSb Γ [] σ []
+  | snoc {Δ Γ A vt t E σ l} :
+    EnvEqSb Δ E σ Γ →
     Γ ⊢[l] A →
-    WfValTm Δ l v (A.subst (sbOfEnv ‖Δ‖ E)) →
-    WfEnv Δ (v :: E) ((A, l) :: Γ)
+    ValEqTm Δ l vt t (A.subst σ) →
+    EnvEqSb Δ (vt :: E) (Expr.snoc σ t) ((A, l) :: Γ)
 end
 
 /-! ## Well-formed evaluation environments -/
 
-namespace WfEnv
+namespace EnvEqSb
 
-theorem wf_dom {Δ} : ∀ {E Γ}, WfEnv Δ E Γ → WfCtx Δ := by
-  mutual_induction WfEnv
+theorem wf_dom {Δ} : ∀ {E σ Γ}, EnvEqSb Δ E σ Γ → WfCtx Δ := by
+  mutual_induction EnvEqSb
   all_goals grind
 
-theorem wf_cod {Δ} : ∀ {E Γ}, WfEnv Δ E Γ → WfCtx Γ := by
-  mutual_induction WfEnv
+theorem wf_cod {Δ} : ∀ {E σ Γ}, EnvEqSb Δ E σ Γ → WfCtx Γ := by
+  mutual_induction EnvEqSb
   all_goals grind [WfCtx.nil, WfCtx.snoc]
 
-theorem eq_length {Δ} : ∀ {E Γ}, WfEnv Δ E Γ → ‖E‖ = ‖Γ‖ := by
-  mutual_induction WfEnv
+theorem eq_length {Δ} : ∀ {E σ Γ}, EnvEqSb Δ E σ Γ → ‖E‖ = ‖Γ‖ := by
+  mutual_induction EnvEqSb
   all_goals intros; try exact True.intro
   all_goals simp; try grind
 
-theorem lookup_lt {Δ Γ E i A l} : WfEnv Δ E Γ → Lookup Γ i A l → i < ‖E‖ :=
+theorem lookup_lt {Δ Γ E σ i A l} : EnvEqSb Δ E σ Γ → Lookup Γ i A l → i < ‖E‖ :=
   fun env lk => env.eq_length ▸ lk.lt_length
 
-theorem lookup_wf {Δ} : ∀ {E Γ}, (env : WfEnv Δ E Γ) →
+theorem lookup_eq {Δ} : ∀ {E σ Γ}, (env : EnvEqSb Δ E σ Γ) →
     ∀ {A i l}, (lk : Lookup Γ i A l) →
-    WfValTm Δ l (E[i]'(env.lookup_lt lk)) (A.subst (sbOfEnv ‖Δ‖ E)) := by
-  mutual_induction WfEnv
+    ValEqTm Δ l (E[i]'(env.lookup_lt lk)) (σ i) (A.subst σ) := by
+  mutual_induction EnvEqSb
   all_goals intros; try exact True.intro
   case nil lk => cases lk
   case snoc E A v ih _ _ _ _ lk =>
     rcases lk with _ | ⟨_, _, lk⟩
-    . convert v using 1
-      autosubst
-      rw [A.sbOfEnv_irrel (E.eq_length ▸ Nat.le_refl _)]
-    . convert ih lk using 1
-      autosubst
-      rw [A.wf_ctx.lookup_wf lk |>.sbOfEnv_irrel (E.eq_length ▸ Nat.le_refl _)]
+    . convert v using 1; autosubst
+    . convert ih lk using 1; autosubst
 
-theorem sbOfEnv_app {Δ Γ A E i l} (env : WfEnv Δ E Γ) (lk : Lookup Γ i A l) :
-    sbOfEnv ‖Δ‖ E 0 i = (E[i]'(env.lookup_lt lk)).toExpr ‖Δ‖ := by
-  simp [sbOfEnv, sbOfTms, List.getElem?_eq_some_iff.mpr ⟨env.lookup_lt lk, rfl⟩]
+lemma Expr.eq_snoc_self (σ : Nat → Expr) : σ = Expr.snoc (Expr.comp σ Expr.wk) (σ 0) := by
+  ext i; cases i <;> rfl
 
-theorem mk : ∀ {Γ}, WfCtx Γ → ∀ {Δ} {E : List Val}, WfCtx Δ → (eq : ‖Γ‖ = ‖E‖) →
+theorem mk : ∀ {Γ}, WfCtx Γ → ∀ {Δ} {E : List Val} {σ}, WfCtx Δ → (eq : ‖Γ‖ = ‖E‖) →
     (∀ {i A l}, (lk : Lookup Γ i A l) →
-      WfValTm Δ l (E[i]'(eq ▸ lk.lt_length)) (A.subst (sbOfEnv ‖Δ‖ E))) →
-    WfEnv Δ E Γ := by
+      ValEqTm Δ l (E[i]'(eq ▸ lk.lt_length)) (σ i) (A.subst σ)) →
+    EnvEqSb Δ E σ Γ := by
   mutual_induction WfCtx
   all_goals intros; try exact True.intro
   case nil eq _ =>
     have := List.length_eq_zero_iff.mp eq.symm
-    grind [WfEnv.nil]
-  case snoc A ih _ _ E Δ eq h =>
+    grind [EnvEqSb.nil]
+  case snoc ih _ _ E σ Δ eq h =>
     cases E
     . cases eq
     . replace eq := Nat.succ_inj.mp eq
-      apply WfEnv.snoc
+      rw [Expr.eq_snoc_self σ]
+      apply EnvEqSb.snoc
       . refine ih Δ eq fun lk => ?_
         convert h (lk.succ ..) using 1; autosubst
-        conv => rhs; rw [A.wf_ctx.lookup_wf lk |>.sbOfEnv_irrel <| eq ▸ Nat.le_refl _]
       . assumption
       . convert h (Lookup.zero ..) using 1; autosubst
-        conv => rhs; rw [A.sbOfEnv_irrel <| eq ▸ Nat.le_refl _]
 
-end WfEnv
+end EnvEqSb
 
 /-! ## Values are well-typed as expressions -/
 
-attribute [local grind] Val.toExpr Neut.toExpr Clos.toExpr in
-theorem wf_toExpr {Γ} :
-    (∀ {l A}, WfValTp Γ l A → Γ ⊢[l] A.toExpr ‖Γ‖) ∧
-    (∀ {l t A}, WfValTm Γ l t A → Γ ⊢[l] t.toExpr ‖Γ‖ : A) ∧
-    (∀ {l t A}, WfNeutTm Γ l t A → Γ ⊢[l] t.toExpr ‖Γ‖ : A) ∧
-    (∀ {l l' A B}, WfClosTp Γ l l' A B → (A, l) :: Γ ⊢[l'] B.toExpr ‖Γ‖) ∧
-    (∀ {l l' A B b}, WfClosTm Γ l l' A B b → (A, l) :: Γ ⊢[l'] b.toExpr ‖Γ‖ : B) ∧
-    (∀ {E Γ'}, WfEnv Γ E Γ' → ∀ (k), WfSb Γ (sbOfEnv ‖Γ‖ E k) Γ') := by
-  mutual_induction WfValTp
+theorem wf_expr {Γ} :
+    (∀ {l vA A}, ValEqTp Γ l vA A → Γ ⊢[l] A) ∧
+    (∀ {l vt t A}, ValEqTm Γ l vt t A → Γ ⊢[l] t : A) ∧
+    (∀ {l vt t A}, NeutEqTm Γ l vt t A → Γ ⊢[l] t : A) ∧
+    (∀ {l l' A vB B}, ClosEqTp Γ l l' A vB B → (A, l) :: Γ ⊢[l'] B) ∧
+    (∀ {l l' A B vb b}, ClosEqTm Γ l l' A B vb b → (A, l) :: Γ ⊢[l'] b : B) ∧
+    (∀ {E σ Γ'}, EnvEqSb Γ E σ Γ' → WfSb Γ σ Γ') := by
+  mutual_induction ValEqTp
   all_goals dsimp; intros
   case pi => grind [WfTp.pi]
   case sigma => grind [WfTp.sigma]
   case univ => grind [WfTp.univ]
   case el => grind [WfTp.el]
+  case conv_tp => grind [EqTp.wf_right]
   case lam => grind [WfTm.lam]
   case pair => grind [WfTm.pair]
   case code => grind [WfTm.code]
   case neut_tm => grind
-  case conv_nf => grind [WfTm.conv]
-  case bvar Γ lk =>
-    unfold Neut.toExpr
-    convert WfTm.bvar Γ lk using 2
-    have := lk.lt_length
-    omega
+  case conv_nf tt' AA' _ => exact tt'.wf_right.conv AA'
+  case bvar Γ lk => exact WfTm.bvar Γ lk
   case app => grind [WfTm.app]
   case fst => grind [WfTm.fst]
   case snd => grind [WfTm.snd]
-  case conv_neut => grind [WfTm.conv]
-  case clos_tp Aenv _ B sb =>
-    have := B.subst (sb 0 |>.up B.wf_ctx.inv_snoc)
-    have := this.conv_binder Aenv
-    convert this using 1
-    rw [Clos.toExpr]
-  case clos_tm Aenv Benv _ b env =>
-    unfold Clos.toExpr
-    have := b.subst (env 0 |>.up b.wf_ctx.inv_snoc)
+  case conv_neut nn' AA' _ => exact nn'.wf_right.conv AA'
+  case clos_tp Aenv B σ =>
+    have := B.subst (σ.up B.wf_binder)
+    exact this.conv_binder Aenv
+  case clos_tm Aenv Benv b σ =>
+    have := b.subst (σ.up b.wf_binder)
     have := this.conv_ctx (EqCtx.refl Aenv.wf_ctx |>.snoc Aenv)
     exact this.conv Benv
   case nil => apply WfSb.terminal; assumption
-  case snoc E A _ _ _ _ =>
-    rw [sbOfEnv_cons]
-    apply WfSb.snoc
-    . grind
-    . grind
-    . rw [A.sbOfEnv_irrel (E.eq_length ▸ Nat.le_refl _)]; grind
+  case snoc => grind [WfSb.snoc]
 
-theorem WfValTp.wf_toExpr {Γ l A} (h : WfValTp Γ l A) : Γ ⊢[l] A.toExpr ‖Γ‖ :=
-  _root_.wf_toExpr.1 h
+theorem ValEqTp.wf_tp {Γ l vA A} (h : ValEqTp Γ l vA A) : Γ ⊢[l] A :=
+  _root_.wf_expr.1 h
 
-theorem WfValTm.wf_toExpr {Γ l t A} (h : WfValTm Γ l t A) : Γ ⊢[l] t.toExpr ‖Γ‖ : A :=
-  _root_.wf_toExpr.2.1 h
+theorem ValEqTm.wf_tm {Γ l vt t A} (h : ValEqTm Γ l vt t A) : Γ ⊢[l] t : A :=
+  _root_.wf_expr.2.1 h
 
-theorem WfNeutTm.wf_toExpr {Γ l t A} (h : WfNeutTm Γ l t A) : Γ ⊢[l] t.toExpr ‖Γ‖ : A :=
-  _root_.wf_toExpr.2.2.1 h
+theorem NeutEqTm.wf_tm {Γ l vt t A} (h : NeutEqTm Γ l vt t A) : Γ ⊢[l] t : A :=
+  _root_.wf_expr.2.2.1 h
 
-theorem WfClosTp.wf_toExpr {Γ l l' A B} (h : WfClosTp Γ l l' A B) :
-    (A, l) :: Γ ⊢[l'] B.toExpr ‖Γ‖ :=
-  _root_.wf_toExpr.2.2.2.1 h
+theorem ClosEqTp.wf_tp {Γ l l' A vB B} (h : ClosEqTp Γ l l' A vB B) :
+    (A, l) :: Γ ⊢[l'] B :=
+  _root_.wf_expr.2.2.2.1 h
 
-theorem WfClosTm.wf_toExpr {Γ A B b l l'} (h : WfClosTm Γ l l' A B b) :
-    (A, l) :: Γ ⊢[l'] b.toExpr ‖Γ‖ : B :=
-  _root_.wf_toExpr.2.2.2.2.1 h
+theorem ClosEqTm.wf_tm {Γ l l' A B vb b} (h : ClosEqTm Γ l l' A B vb b) :
+    (A, l) :: Γ ⊢[l'] b : B :=
+  _root_.wf_expr.2.2.2.2.1 h
 
-theorem WfEnv.wf_sbOfEnv {Δ E Γ} (h : WfEnv Δ E Γ) : WfSb Δ (sbOfEnv ‖Δ‖ E) Γ :=
-  _root_.wf_toExpr.2.2.2.2.2 h 0
+theorem EnvEqSb.wf_sb {Δ E σ Γ} (h : EnvEqSb Δ E σ Γ) : WfSb Δ σ Γ :=
+  _root_.wf_expr.2.2.2.2.2 h
 
-/-! ## Values are closed under conversion -/
+theorem ValEqTm.conv_tp {Γ A A' vt t l} :
+    ValEqTm Γ l vt t A → Γ ⊢[l] A ≡ A' → ValEqTm Γ l vt t A' :=
+  fun h eq => h.conv_nf (EqTm.refl_tm h.wf_tm) eq
+
+theorem NeutEqTm.conv_tp {Γ A A' vt t l} :
+    NeutEqTm Γ l vt t A → Γ ⊢[l] A ≡ A' → NeutEqTm Γ l vt t A' :=
+  fun h eq => h.conv_neut (EqTm.refl_tm h.wf_tm) eq
+
+/-! ## Values are closed under context conversion -/
 
 attribute [local grind] EqCtx.length_eq in
 theorem conv_ctx {Γ} :
-    (∀ {l A}, WfValTp Γ l A → ∀ {Γ'}, EqCtx Γ Γ' → WfValTp Γ' l A) ∧
-    (∀ {l t A}, WfValTm Γ l t A → ∀ {Γ'}, EqCtx Γ Γ' → WfValTm Γ' l t A) ∧
-    (∀ {l t A}, WfNeutTm Γ l t A → ∀ {Γ'}, EqCtx Γ Γ' → WfNeutTm Γ' l t A) ∧
-    (∀ {l l' A B}, WfClosTp Γ l l' A B → ∀ {Γ'}, EqCtx Γ Γ' → WfClosTp Γ' l l' A B) ∧
-    (∀ {l l' A B b}, WfClosTm Γ l l' A B b → ∀ {Γ'}, EqCtx Γ Γ' → WfClosTm Γ' l l' A B b) ∧
-    (∀ {E Δ}, WfEnv Γ E Δ → ∀ {Γ'}, EqCtx Γ Γ' → WfEnv Γ' E Δ) := by
-  mutual_induction WfValTp
-  all_goals intros; try exact True.intro
-  case pi => grind [WfValTp.pi, EqTp.refl_tp]
-  case sigma => grind [WfValTp.sigma, EqTp.refl_tp]
-  case univ => grind [WfValTp.univ, EqCtx.wf_right]
-  case el => grind [WfValTp.el]
-  case lam eq => grind [WfValTm.lam]
+    (∀ {l vA A}, ValEqTp Γ l vA A → ∀ {Γ'}, EqCtx Γ Γ' → ValEqTp Γ' l vA A) ∧
+    (∀ {l vt t A}, ValEqTm Γ l vt t A → ∀ {Γ'}, EqCtx Γ Γ' → ValEqTm Γ' l vt t A) ∧
+    (∀ {l vt t A}, NeutEqTm Γ l vt t A → ∀ {Γ'}, EqCtx Γ Γ' → NeutEqTm Γ' l vt t A) ∧
+    (∀ {l l' A vB B}, ClosEqTp Γ l l' A vB B → ∀ {Γ'}, EqCtx Γ Γ' → ClosEqTp Γ' l l' A vB B) ∧
+    (∀ {l l' A B vb b}, ClosEqTm Γ l l' A B vb b → ∀ {Γ'}, EqCtx Γ Γ' →
+      ClosEqTm Γ' l l' A B vb b) ∧
+    (∀ {E σ Δ}, EnvEqSb Γ E σ Δ → ∀ {Γ'}, EqCtx Γ Γ' → EnvEqSb Γ' E σ Δ) := by
+  mutual_induction ValEqTp
+  all_goals intros
+  case pi => grind [ValEqTp.pi]
+  case sigma => grind [ValEqTp.sigma]
+  case univ => grind [ValEqTp.univ, EqCtx.wf_right]
+  case el => grind [ValEqTp.el]
+  case conv_tp => grind [ValEqTp.conv_tp, EqTp.conv_ctx]
+  case lam eq => grind [ValEqTm.lam]
   case pair B _ _ _ _ _ eq =>
-    apply WfValTm.pair (B.conv_ctx (eq.snoc <| EqTp.refl_tp B.wf_ctx.inv_snoc)) <;>
+    apply ValEqTm.pair (B.conv_ctx (eq.snoc <| EqTp.refl_tp B.wf_binder)) <;>
       grind
-  case code => grind [WfValTm.code]
-  case neut_tm => grind [WfValTm.neut_tm]
-  case conv_nf => grind [EqTp.conv_ctx, WfValTm.conv_nf]
+  case code => grind [ValEqTm.code]
+  case neut_tm => grind [ValEqTm.neut_tm]
+  case conv_nf => grind [EqTm.conv_ctx, EqTp.conv_ctx, ValEqTm.conv_nf]
   case bvar lk _ eq =>
     have ⟨A', _, lk'⟩ := Lookup.of_lt_length <| eq.length_eq ▸ lk.lt_length
     obtain ⟨rfl, eqA⟩ := eq.lookup_eq lk lk'
-    have := WfNeutTm.bvar eq.wf_right lk'
+    have := NeutEqTm.bvar eq.wf_right lk'
     rw [eq.length_eq]
-    exact WfNeutTm.conv_neut this (eqA.symm_tp.conv_ctx eq)
-  case app eq =>
-    rw [eq.length_eq]
-    grind [WfNeutTm.app]
-  case fst => grind [WfNeutTm.fst]
-  case snd B _ _ _ eq =>
-    rw [eq.length_eq]
-    grind [WfNeutTm.snd]
-  case conv_neut => grind [EqTp.conv_ctx, WfNeutTm.conv_neut]
-  case clos_tp Aeq env _ _ _ eq =>
-    rw [eq.length_eq] at Aeq
-    grind [WfClosTp.clos_tp, EqTp.conv_ctx]
-  case clos_tm Aeq Beq env b _ _ eq =>
-    rw [eq.length_eq] at Aeq Beq
-    apply WfClosTm.clos_tm _ (Beq.conv_ctx _)
-    all_goals grind [EqTp.conv_ctx, EqCtx.snoc, EqTp.refl_tp, EqTp.wf_right]
-  case nil eq => exact .nil eq.wf_right
-  case snoc => grind [WfEnv.snoc]
+    exact NeutEqTm.conv_neut this (EqTm.refl_tm (wf_expr.2.2.1 this)) (eqA.symm_tp.conv_ctx eq)
+  case app eq => grind [NeutEqTm.app]
+  case fst => grind [NeutEqTm.fst]
+  case snd => grind [NeutEqTm.snd]
+  case conv_neut => grind [EqTm.conv_ctx, EqTp.conv_ctx, NeutEqTm.conv_neut]
+  case clos_tp => grind [ClosEqTp.clos_tp, EqTp.conv_ctx]
+  case clos_tm Aeq Beq b env _ eq =>
+    exact ClosEqTm.clos_tm (env eq) (Aeq.conv_ctx eq)
+      (Beq.conv_ctx <| eq.snoc <| EqTp.refl_tp Aeq.wf_right)
+      (b.conv_ctx b.wf_ctx.eq_self)
+  case nil eq => exact .nil _ eq.wf_right
+  case snoc => grind [EnvEqSb.snoc]
 
-theorem WfValTp.conv_ctx {Γ Γ' l A} : WfValTp Γ l A → EqCtx Γ Γ' → WfValTp Γ' l A :=
+theorem ValEqTp.conv_ctx {Γ Γ' l vA A} : ValEqTp Γ l vA A → EqCtx Γ Γ' → ValEqTp Γ' l vA A :=
   fun h eq => _root_.conv_ctx.1 h eq
 
-theorem WfValTm.conv_ctx {Γ Γ' l t A} : WfValTm Γ l t A → EqCtx Γ Γ' → WfValTm Γ' l t A :=
+theorem ValEqTm.conv_ctx {Γ Γ' l vt t A} : ValEqTm Γ l vt t A → EqCtx Γ Γ' →
+    ValEqTm Γ' l vt t A :=
   fun h eq => _root_.conv_ctx.2.1 h eq
 
-theorem WfNeutTm.conv_ctx {Γ Γ' l t A} : WfNeutTm Γ l t A → EqCtx Γ Γ' → WfNeutTm Γ' l t A :=
+theorem NeutEqTm.conv_ctx {Γ Γ' l vt t A} : NeutEqTm Γ l vt t A → EqCtx Γ Γ' →
+    NeutEqTm Γ' l vt t A :=
   fun h eq => _root_.conv_ctx.2.2.1 h eq
 
-theorem WfClosTp.conv_ctx {Γ Γ' l l' A B} : WfClosTp Γ l l' A B → EqCtx Γ Γ' →
-    WfClosTp Γ' l l' A B :=
+theorem ClosEqTp.conv_ctx {Γ Γ' l l' A vB B} : ClosEqTp Γ l l' A vB B → EqCtx Γ Γ' →
+    ClosEqTp Γ' l l' A vB B :=
   fun h eq => _root_.conv_ctx.2.2.2.1 h eq
 
-theorem WfClosTm.conv_ctx {Γ Γ' l l' A B b} :
-    WfClosTm Γ l l' A B b → EqCtx Γ Γ' → WfClosTm Γ' l l' A B b :=
+theorem ClosEqTm.conv_ctx {Γ Γ' l l' A B vb b} :
+    ClosEqTm Γ l l' A B vb b → EqCtx Γ Γ' → ClosEqTm Γ' l l' A B vb b :=
   fun h eq => _root_.conv_ctx.2.2.2.2.1 h eq
 
-theorem WfEnv.conv_dom {Δ Δ' Γ E} : WfEnv Δ E Γ → EqCtx Δ Δ' → WfEnv Δ' E Γ :=
+theorem EnvEqSb.conv_dom {Δ Δ' E σ Γ} : EnvEqSb Δ E σ Γ → EqCtx Δ Δ' → EnvEqSb Δ' E σ Γ :=
   fun h eq => _root_.conv_ctx.2.2.2.2.2 h eq
 
 /-! ## Environments from contexts -/
@@ -481,81 +406,335 @@ theorem envOfLen_succ (n : Nat) : envOfLen (n + 1) = (.neut <| .bvar n) :: envOf
   dsimp
   omega
 
-@[autosubst]
-theorem sbOfEnv_envOfLen (n : Nat) : sbOfEnv n (envOfLen n) = Expr.bvar := by
-  ext i
-  simp [sbOfEnv, sbOfTms, envOfLen, Val.toExpr, Neut.toExpr]
-  split_ifs <;> simp
-  . omega
-
-theorem envOfLen_wf {Γ} : WfCtx Γ → WfEnv Γ (envOfLen ‖Γ‖) Γ := by
+theorem envOfLen_wf {Γ} : WfCtx Γ → EnvEqSb Γ (envOfLen ‖Γ‖) Expr.bvar Γ := by
   intro Γ
-  refine WfEnv.mk Γ Γ (length_envOfLen _).symm fun lk => ?_
-  conv => enter [3]; simp only [envOfLen, List.getElem_ofFn]
-  apply WfValTm.neut_tm
-  apply WfNeutTm.bvar Γ
-  convert lk; autosubst
+  refine EnvEqSb.mk Γ Γ (length_envOfLen _).symm fun lk => ?_
+  simp only [envOfLen, List.getElem_ofFn]
+  apply ValEqTm.neut_tm
+  apply NeutEqTm.bvar Γ
+  convert lk using 1; autosubst
 
-/-! ## Inversion for well-formed values -/
+/-! ## Weakening is free -/
 
-theorem WfValTp.inv_pi {Γ vA vB l k k'} : WfValTp Γ l (.pi k k' vA vB) →
-    l = max k k' ∧ WfValTp Γ k vA ∧ WfClosTp Γ k k' (vA.toExpr ‖Γ‖) vB := by
-  suffices ∀ {l t}, WfValTp Γ l t →
-      ∀ {vA vB k k'}, t = .pi k k' vA vB →
-        l = max k k' ∧ WfValTp Γ k vA ∧ WfClosTp Γ k k' (vA.toExpr ‖Γ‖) vB from
+theorem wk_all {Γ} :
+    (∀ {l vA A}, ValEqTp Γ l vA A → ∀ {C k}, Γ ⊢[k] C →
+      ValEqTp ((C,k) :: Γ) l vA (A.subst Expr.wk)) ∧
+    (∀ {l vt t A}, ValEqTm Γ l vt t A → ∀ {C k}, Γ ⊢[k] C →
+      ValEqTm ((C,k) :: Γ) l vt (t.subst Expr.wk) (A.subst Expr.wk)) ∧
+    (∀ {l vt t A}, NeutEqTm Γ l vt t A → ∀ {C k}, Γ ⊢[k] C →
+      NeutEqTm ((C,k) :: Γ) l vt (t.subst Expr.wk) (A.subst Expr.wk)) ∧
+    (∀ {l l' A vB B}, ClosEqTp Γ l l' A vB B → ∀ {C k}, Γ ⊢[k] C →
+      ClosEqTp ((C,k) :: Γ) l l' (A.subst Expr.wk) vB (B.subst (Expr.up Expr.wk))) ∧
+    (∀ {l l' A B vb b}, ClosEqTm Γ l l' A B vb b → ∀ {C k}, Γ ⊢[k] C →
+      ClosEqTm ((C,k) :: Γ) l l' (A.subst Expr.wk) (B.subst (Expr.up Expr.wk))
+        vb (b.subst (Expr.up Expr.wk))) ∧
+    (∀ {E σ Δ}, EnvEqSb Γ E σ Δ → ∀ {C k}, Γ ⊢[k] C →
+      EnvEqSb ((C,k) :: Γ) E (Expr.comp Expr.wk σ) Δ) := by
+  mutual_induction ValEqTp
+  all_goals intros; try dsimp [Expr.subst] at *
+  case pi => grind [ValEqTp.pi]
+  case sigma => grind [ValEqTp.sigma]
+  case univ => grind [ValEqTp.univ, WfCtx.snoc]
+  case el => grind [ValEqTp.el]
+  case conv_tp => grind [ValEqTp.conv_tp, EqTp.subst, WfSb.wk]
+  case lam eq => grind [ValEqTm.lam]
+  case pair B _ _ iht ihu _ _ C =>
+    have := B.subst (WfSb.wk C |>.up B.wf_binder)
+    apply ValEqTm.pair this (iht C) (by convert ihu C using 1; autosubst)
+  case code => grind [ValEqTm.code]
+  case neut_tm => grind [ValEqTm.neut_tm]
+  case conv_nf => grind [ValEqTm.conv_nf, EqTp.subst, EqTm.subst, WfSb.wk]
+  case bvar Γ lk _ _ C =>
+    convert NeutEqTm.bvar (Γ.snoc C) (.succ _ _ lk) using 1; grind
+  case app ihf iha _ _ C =>
+    convert NeutEqTm.app (ihf C) (iha C) using 1; autosubst
+  case fst => grind [NeutEqTm.fst]
+  case snd ih _ _ C =>
+    convert NeutEqTm.snd (ih C) using 1; autosubst
+  case conv_neut => grind [NeutEqTm.conv_neut, EqTp.subst, EqTm.subst, WfSb.wk]
+  case clos_tp Aeq B ih _ _ C =>
+    have := Aeq.subst (WfSb.wk C)
+    convert ClosEqTp.clos_tp (ih C) (by convert this using 1; autosubst) B using 1
+    autosubst
+  case clos_tm Aeq Beq b ih _ _ C =>
+    have CAeq := Aeq.subst <| WfSb.wk C
+    have CBeq := Beq.subst <| (WfSb.wk C).up Aeq.wf_right
+    have := ClosEqTm.clos_tm (ih C)
+      (by convert CAeq using 1; autosubst)
+      (by convert CBeq using 1; autosubst)
+      b
+    convert this using 1; autosubst
+  case nil C => apply EnvEqSb.nil _ (C.wf_ctx.snoc C)
+  case snoc =>
+    simp only [autosubst] at *
+    grind [EnvEqSb.snoc]
+
+/-! ## Inversion for value relations -/
+
+theorem ValEqTp.inv_pi {Γ C vA vB l k k'} : ValEqTp Γ l (.pi k k' vA vB) C →
+    l = max k k' ∧ ∃ A B, ValEqTp Γ k vA A ∧ ClosEqTp Γ k k' A vB B ∧
+      (Γ ⊢[max k k'] C ≡ .pi k k' A B) := by
+  suffices ∀ {l vC C}, ValEqTp Γ l vC C →
+      ∀ {vA vB k k'}, vC = .pi k k' vA vB →
+        l = max k k' ∧ ∃ A B, ValEqTp Γ k vA A ∧ ClosEqTp Γ k k' A vB B ∧
+        (Γ ⊢[max k k'] C ≡ .pi k k' A B) from
     fun h => this h rfl
-  mutual_induction WfValTp
-  all_goals grind
+  mutual_induction ValEqTp
+  all_goals grind [WfTp.pi, ClosEqTp.wf_tp]
 
-theorem WfValTp.inv_sigma {Γ vA vB l k k'} : WfValTp Γ l (.sigma k k' vA vB) →
-    l = max k k' ∧ WfValTp Γ k vA ∧ WfClosTp Γ k k' (vA.toExpr ‖Γ‖) vB := by
-  suffices ∀ {l t}, WfValTp Γ l t →
-      ∀ {vA vB k k'}, t = .sigma k k' vA vB →
-        l = max k k' ∧ WfValTp Γ k vA ∧ WfClosTp Γ k k' (vA.toExpr ‖Γ‖) vB from
+theorem ValEqTp.inv_sigma {Γ C vA vB l k k'} : ValEqTp Γ l (.sigma k k' vA vB) C →
+    l = max k k' ∧ ∃ A B, ValEqTp Γ k vA A ∧ ClosEqTp Γ k k' A vB B ∧
+      (Γ ⊢[max k k'] C ≡ .sigma k k' A B) := by
+  suffices ∀ {l vC C}, ValEqTp Γ l vC C →
+      ∀ {vA vB k k'}, vC = .sigma k k' vA vB →
+        l = max k k' ∧ ∃ A B, ValEqTp Γ k vA A ∧ ClosEqTp Γ k k' A vB B ∧
+        (Γ ⊢[max k k'] C ≡ .sigma k k' A B) from
     fun h => this h rfl
-  mutual_induction WfValTp
-  all_goals grind
+  mutual_induction ValEqTp
+  all_goals grind [WfTp.sigma, ClosEqTp.wf_tp]
 
-theorem WfValTm.inv_lam {Γ A C b l₀ l l'} : WfValTm Γ l₀ (.lam l l' A b) C →
-    l₀ = max l l' ∧ ∃ B, (WfClosTm Γ l l' A B b) ∧ (Γ ⊢[max l l'] C ≡ .pi l l' A B) := by
+theorem ValEqTp.inv_univ {Γ l k t} : ValEqTp Γ l (.univ k) t → l = k + 1 ∧
+    (Γ ⊢[k + 1] t ≡ .univ k) := by
+  suffices ∀ {l vt t}, ValEqTp Γ l vt t → ∀ {k}, vt = .univ k → l = k + 1 ∧
+      (Γ ⊢[k + 1] t ≡ .univ k) from
+    fun h => this h rfl
+  mutual_induction ValEqTp
+  all_goals grind [WfTp.univ]
+
+theorem ValEqTp.inv_el {Γ l va A} : ValEqTp Γ l (.el va) A →
+    ∃ a, ValEqTm Γ (l + 1) va a (.univ l) ∧ (Γ ⊢[l] A ≡ .el a) := by
+  suffices ∀ {l vA A}, ValEqTp Γ l vA A → ∀ {va}, vA = .el va →
+      ∃ a, ValEqTm Γ (l + 1) va a (.univ l) ∧ (Γ ⊢[l] A ≡ .el a) from
+    fun h => this h rfl
+  mutual_induction ValEqTp
+  all_goals grind [WfTp.el, ValEqTm.wf_tm]
+
+theorem ValEqTm.inv_lam {Γ C vb t l₀ l l'} : ValEqTm Γ l₀ (.lam l l' vb) t C →
+    l₀ = max l l' ∧ ∃ A B b, (ClosEqTm Γ l l' A B vb b) ∧
+      (Γ ⊢[max l l'] t ≡ .lam l l' A b : C) ∧
+      (Γ ⊢[max l l'] C ≡ .pi l l' A B) := by
   suffices
-      ∀ {l₀ t C}, WfValTm Γ l₀ t C → ∀ {A b l l'}, t = .lam l l' A b →
-        l₀ = max l l' ∧ ∃ B, (WfClosTm Γ l l' A B b) ∧ (Γ ⊢[max l l'] C ≡ .pi l l' A B) from
+      ∀ {l₀ vt t C}, ValEqTm Γ l₀ vt t C → ∀ {l l'}, vt = .lam l l' vb →
+        l₀ = max l l' ∧ ∃ A B b, (ClosEqTm Γ l l' A B vb b) ∧
+          (Γ ⊢[max l l'] t ≡ .lam l l' A b : C) ∧
+          (Γ ⊢[max l l'] C ≡ .pi l l' A B) from
     fun h => this h rfl
-  mutual_induction WfValTm
+  mutual_induction ValEqTm
   all_goals intros; try exact True.intro
   all_goals rename_i eq; cases eq
-  case lam b _ =>
-    refine ⟨rfl, _, by assumption, ?_⟩
-    rcases b with ⟨_, eq, _, _⟩
-    exact EqTp.refl_tp <| WfTp.pi eq.wf_right
-  case conv_nf =>
-    grind [EqTp.symm_tp, EqTp.trans_tp]
+  case conv_nf => grind [EqTm.conv_eq]
+  case lam => grind [WfTm.lam, ClosEqTm.wf_tm, WfTm.wf_tp, WfTp.pi]
 
-theorem WfValTm.inv_pair {Γ B C t u l₀ l l'} : WfValTm Γ l₀ (.pair l l' B t u) C →
-    l₀ = max l l' ∧ ∃ A, (WfValTm Γ l t A) ∧ (WfValTm Γ l' u (B.subst (t.toExpr ‖Γ‖).toSb)) ∧
+theorem ValEqTm.inv_pair {Γ C vt vu p l₀ l l'} : ValEqTm Γ l₀ (.pair l l' vt vu) p C →
+    l₀ = max l l' ∧ ∃ A B t u, (ValEqTm Γ l vt t A) ∧ (ValEqTm Γ l' vu u (B.subst t.toSb)) ∧
+      (Γ ⊢[max l l'] p ≡ .pair l l' B t u : C) ∧
       (Γ ⊢[max l l'] C ≡ .sigma l l' A B) := by
   suffices
-      ∀ {l₀ t₀ C}, WfValTm Γ l₀ t₀ C → ∀ {B t u l l'}, t₀ = .pair l l' B t u →
-        l₀ = max l l' ∧ ∃ A,
-          (WfValTm Γ l t A) ∧
-          (WfValTm Γ l' u (B.subst (t.toExpr ‖Γ‖).toSb)) ∧
+      ∀ {l₀ vp p C}, ValEqTm Γ l₀ vp p C → ∀ {vt vu l l'}, vp = .pair l l' vt vu →
+        l₀ = max l l' ∧ ∃ A B t u,
+          (ValEqTm Γ l vt t A) ∧
+          (ValEqTm Γ l' vu u (B.subst t.toSb)) ∧
+          (Γ ⊢[max l l'] p ≡ .pair l l' B t u : C) ∧
           (Γ ⊢[max l l'] C ≡ .sigma l l' A B) from
     fun h => this h rfl
-  mutual_induction WfValTm
+  mutual_induction ValEqTm
   all_goals intros; try exact True.intro
   all_goals rename_i eq; cases eq
-  case pair =>
-    refine ⟨rfl, _, by assumption, by assumption, ?_⟩
-    grind [EqTp.refl_tp, WfTp.sigma, WfClosTp.wf_toExpr]
-  case conv_nf =>
-    grind [EqTp.symm_tp, EqTp.trans_tp]
+  case conv_nf => grind [EqTm.conv_eq]
+  case pair => grind [WfTm.pair, ValEqTm.wf_tm, WfTp.sigma]
 
-theorem WfValTm.inv_neut {Γ A t l} : WfValTm Γ l (.neut t) A → WfNeutTm Γ l t A := by
-  suffices ∀ {l t A}, WfValTm Γ l t A → ∀ {n}, t = .neut n → (WfNeutTm Γ l n A) from
+theorem ValEqTm.inv_code {Γ C vA c l₀} : ValEqTm Γ l₀ (.code vA) c C →
+    ∃ l A, l₀ = l + 1 ∧ (ValEqTp Γ l vA A) ∧ (Γ ⊢[l₀] c ≡ .code A : C) ∧ (Γ ⊢[l₀] C ≡ .univ l) := by
+  suffices
+      ∀ {l₀ vc c C}, ValEqTm Γ l₀ vc c C → ∀ {vA}, vc = .code vA →
+        ∃ l A, l₀ = l + 1 ∧ (ValEqTp Γ l vA A) ∧ (Γ ⊢[l₀] c ≡ .code A : C) ∧ (Γ ⊢[l₀] C ≡ .univ l) from
     fun h => this h rfl
-  mutual_induction WfValTm
+  mutual_induction ValEqTm
   all_goals intros; try exact True.intro
   all_goals rename_i eq; cases eq
-  case neut_tm => assumption
-  case conv_nf eq _ _ ih => exact ih rfl |>.conv_neut eq
+  case conv_nf => grind [EqTm.conv_eq]
+  case code => grind [WfTp.univ, WfTm.code, ValEqTp.wf_tp, WfTp.wf_ctx]
+
+theorem ValEqTm.inv_neut {Γ A vt t l} : ValEqTm Γ l (.neut vt) t A → NeutEqTm Γ l vt t A := by
+  suffices ∀ {l vt t A}, ValEqTm Γ l vt t A → ∀ {n}, vt = .neut n → (NeutEqTm Γ l n t A) from
+    fun h => this h rfl
+  mutual_induction ValEqTm
+  all_goals grind [NeutEqTm.conv_neut]
+
+theorem NeutEqTm.inv_bvar {Γ A t i l} : NeutEqTm Γ l (.bvar i) t A →
+    ∃ A', Lookup Γ (‖Γ‖ - i - 1) A' l ∧
+      (Γ ⊢[l] t ≡ .bvar (‖Γ‖ - i - 1) : A) ∧ (Γ ⊢[l] A ≡ A') := by
+  suffices ∀ {l vn n A}, NeutEqTm Γ l vn n A → ∀ {i}, vn = .bvar i →
+      ∃ A', Lookup Γ (‖Γ‖ - i - 1) A' l ∧
+        (Γ ⊢[l] n ≡ .bvar (‖Γ‖ - i - 1) : A) ∧ (Γ ⊢[l] A ≡ A') from
+    fun h => this h rfl
+  mutual_induction NeutEqTm
+  all_goals intros; try exact True.intro
+  all_goals rename_i eq; cases eq
+  case bvar i _ Γwf lk =>
+    have := lk.lt_length
+    rw [show ‖Γ‖ - (‖Γ‖ - i - 1) - 1 = i by omega]
+    exact ⟨_, lk, EqTm.refl_tm (WfTm.bvar (by omega) lk), EqTp.refl_tp (Γwf.lookup_wf lk)⟩
+  case conv_neut => grind [EqTm.conv_eq]
+
+theorem NeutEqTm.inv_app {Γ C vf va t l₀ l l'} : NeutEqTm Γ l₀ (.app l l' vf va) t C →
+    l₀ = l' ∧ ∃ A B f a, NeutEqTm Γ (max l l') vf f (.pi l l' A B) ∧ ValEqTm Γ l va a A ∧
+      (Γ ⊢[l'] t ≡ .app l l' B f a : C) ∧ (Γ ⊢[l'] C ≡ B.subst a.toSb) := by
+  suffices ∀ {l₀ vn n C}, NeutEqTm Γ l₀ vn n C → ∀ {vf va l l'}, vn = .app l l' vf va →
+      l₀ = l' ∧ ∃ A B f a, NeutEqTm Γ (max l l') vf f (.pi l l' A B) ∧ ValEqTm Γ l va a A ∧
+        (Γ ⊢[l'] n ≡ .app l l' B f a : C) ∧ (Γ ⊢[l'] C ≡ B.subst a.toSb) from
+    fun h => this h rfl
+  mutual_induction NeutEqTm
+  all_goals intros; try exact True.intro
+  all_goals rename_i eq; cases eq
+  case conv_neut => grind [EqTm.conv_eq]
+  case app =>
+    grind [WfTm.app, ValEqTm.wf_tm, NeutEqTm.wf_tm, WfSb.toSb, WfTp.subst, WfTp.inv_pi, WfTm.wf_tp]
+
+theorem NeutEqTm.inv_fst {Γ C vp f l₀ l l'} : NeutEqTm Γ l₀ (.fst l l' vp) f C →
+    l₀ = l ∧ ∃ A B p, NeutEqTm Γ (max l l') vp p (.sigma l l' A B) ∧
+      (Γ ⊢[l] f ≡ .fst l l' A B p : C) ∧ (Γ ⊢[l] C ≡ A) := by
+  suffices ∀ {l₀ vn n C}, NeutEqTm Γ l₀ vn n C → ∀ {vp l l'}, vn = .fst l l' vp →
+      l₀ = l ∧ ∃ A B p, NeutEqTm Γ (max l l') vp p (.sigma l l' A B) ∧
+      (Γ ⊢[l] n ≡ .fst l l' A B p : C) ∧ (Γ ⊢[l] C ≡ A) from
+    fun h => this h rfl
+  mutual_induction NeutEqTm
+  all_goals intros; try exact True.intro
+  all_goals rename_i eq; cases eq
+  case conv_neut => grind [EqTm.conv_eq]
+  case fst =>
+    grind [WfTm.fst, NeutEqTm.wf_tm, WfTm.wf_tp, WfTp.inv_sigma, WfTp.wf_ctx, WfCtx.inv_snoc]
+
+theorem NeutEqTm.inv_snd {Γ C vp s l₀ l l'} : NeutEqTm Γ l₀ (.snd l l' vp) s C →
+    l₀ = l' ∧ ∃ A B p, NeutEqTm Γ (max l l') vp p (.sigma l l' A B) ∧
+      (Γ ⊢[l'] s ≡ .snd l l' A B p : C) ∧ (Γ ⊢[l'] C ≡ B.subst (Expr.fst l l' A B p).toSb) := by
+  suffices ∀ {l₀ vn n C}, NeutEqTm Γ l₀ vn n C → ∀ {vp l l'}, vn = .snd l l' vp →
+      l₀ = l' ∧ ∃ A B p, NeutEqTm Γ (max l l') vp p (.sigma l l' A B) ∧
+      (Γ ⊢[l'] n ≡ .snd l l' A B p : C) ∧ (Γ ⊢[l'] C ≡ B.subst (Expr.fst l l' A B p).toSb) from
+    fun h => this h rfl
+  mutual_induction NeutEqTm
+  all_goals intros; try exact True.intro
+  all_goals rename_i eq; cases eq
+  case conv_neut => grind [EqTm.conv_eq]
+  case snd =>
+    grind [WfTm.snd, NeutEqTm.wf_tm, WfTm.wf_tp, WfTp.inv_sigma, WfTp.wf_ctx, WfCtx.inv_snoc]
+
+/-! ## Functionality of value relations -/
+
+theorem uniq_all {Γ} :
+    (∀ {l vA A}, ValEqTp Γ l vA A → ∀ {A'}, ValEqTp Γ l vA A' → Γ ⊢[l] A ≡ A') ∧
+    (∀ {l vt t A}, ValEqTm Γ l vt t A → ∀ {t'}, ValEqTm Γ l vt t' A → Γ ⊢[l] t ≡ t' : A) ∧
+    /- Technicality: `ValEqTm` does not need the generalization to `A'`
+    because the only terms that 'forget' type information
+    are elimination forms which must be neutral as values. -/
+    (∀ {l vt t A}, NeutEqTm Γ l vt t A → ∀ {t' A'}, NeutEqTm Γ l vt t' A' →
+      (Γ ⊢[l] A ≡ A') ∧ (Γ ⊢[l] t ≡ t' : A)) ∧
+    (∀ {l l' A vB B}, ClosEqTp Γ l l' A vB B → ∀ {B'}, ClosEqTp Γ l l' A vB B' →
+      (A, l) :: Γ ⊢[l'] B ≡ B') ∧
+    (∀ {l l' A B vb b}, ClosEqTm Γ l l' A B vb b → ∀ {b'}, ClosEqTm Γ l l' A B vb b' →
+      (A, l) :: Γ ⊢[l'] b ≡ b' : B) ∧
+    (∀ {E σ Γ'}, EnvEqSb Γ E σ Γ' → ∀ {σ'}, EnvEqSb Γ E σ' Γ' →
+      EqSb Γ σ σ' Γ') := by
+  /- 2025-07-20: I think this could go by induction on `Val`,
+  but my `mutual_induction` tactic doesn't support that. -/
+  mutual_induction ValEqTp
+  all_goals dsimp; intros; try exact True.intro
+  case pi => grind [ValEqTp.inv_pi, cases ClosEqTp, ClosEqTp.clos_tp, EqTp.cong_pi]
+  case sigma => grind [ValEqTp.inv_sigma, cases ClosEqTp, ClosEqTp.clos_tp, EqTp.cong_sigma]
+  case univ h =>
+    have := h.inv_univ
+    grind
+  case el => grind [ValEqTp.inv_el, EqTp.cong_el]
+  case conv_tp => grind
+  case lam ihb _ vl =>
+    have ⟨_, _, _, _, vb, eqt, eq⟩ := vl.inv_lam
+    apply EqTm.trans_tm _ eqt.symm_tm
+    have ⟨_, _, _, Aeq, Beq⟩ := eq.inv_pi
+    gcongr
+    rcases vb with ⟨env, Aeq', Beq', b⟩
+    have Aeq'' := Aeq'.trans_tp Aeq.symm_tp
+    have := Beq'.conv_binder Aeq.symm_tp |>.trans_tp Beq.symm_tp
+    exact ihb ⟨env, Aeq'', this, b⟩
+  case pair iht ihu _ vp =>
+    have ⟨_, _, _, _, _, vt, vu, eqt, eq⟩ := vp.inv_pair
+    apply EqTm.trans_tm _ eqt.symm_tm
+    have ⟨_, _, _, Aeq, Beq⟩ := eq.inv_sigma
+    have := iht (vt.conv_tp Aeq.symm_tp)
+    gcongr
+    . apply ihu (vu.conv_tp _)
+      exact Beq.symm_tp.subst_eq (EqSb.toSb this.symm_tm)
+  case code => grind [ValEqTm.inv_code, EqTm.cong_code]
+  case neut_tm vn =>
+    have := vn.inv_neut
+    grind
+  case conv_nf Aeq ih _ vt =>
+    have := ih (vt.conv_tp Aeq.symm_tp)
+    grind [EqTm.conv_eq]
+  case bvar lk _ _ _ =>
+    have := lk.lt_length
+    grind [EqTm.conv_eq, Lookup.tp_uniq, NeutEqTm.inv_bvar]
+  case app ihf iha _ _ vn =>
+    have ⟨_, _, _, _, _, vf, va, eqt, eq⟩ := vn.inv_app
+    have ⟨peq, feq⟩ := ihf vf
+    have ⟨_, _, _, Aeq, Beq⟩ := peq.inv_pi
+    have aeq := iha <| va.conv_tp Aeq.symm_tp
+    refine ⟨?teq, (fun teq => ?_) ?teq⟩
+    . apply EqTp.trans_tp _ eq.symm_tp
+      exact Beq.subst_eq (EqSb.toSb aeq)
+    . apply EqTm.trans_tm _ <| eqt.symm_tm.conv_eq (by grind)
+      gcongr
+  case fst ih _ _ vn =>
+    have ⟨_, _, _, _, vp, eqt, eq⟩ := vn.inv_fst
+    have ⟨seq, peq⟩ := ih vp
+    have ⟨_, _, _, Aeq, Beq⟩ := seq.inv_sigma
+    constructor
+    . grind
+    . apply EqTm.trans_tm _ <| eqt.symm_tm.conv_eq (by grind)
+      gcongr
+  case snd ih _ _ vn =>
+    have ⟨_, _, _, _, vp, eqt, eq⟩ := vn.inv_snd
+    have ⟨seq, peq⟩ := ih vp
+    have ⟨_, _, _, Aeq, Beq⟩ := seq.inv_sigma
+    refine ⟨?teq2, (fun teq => ?_) ?teq2⟩
+    . apply EqTp.trans_tp _ eq.symm_tp
+      gcongr
+      apply EqSb.toSb
+      gcongr
+    . apply EqTm.trans_tm _ <| eqt.symm_tm.conv_eq (by grind)
+      gcongr
+  case conv_neut => grind [EqTm.conv_eq]
+  case clos_tp ih _ c =>
+    rcases c with ⟨env, Aeq, B⟩
+    have A := B.wf_binder
+    have := B.subst_eq ((ih env).up A)
+    exact this.conv_binder <| (A.subst_eq (ih env)).trans_tp Aeq
+  case clos_tm ih _ c =>
+    rcases c with ⟨env, Aeq, Beq, b⟩
+    have A := b.wf_binder
+    have := b.subst_eq ((ih env).symm.up A) |>.conv_binder Aeq
+      |>.conv_eq Beq
+    exact this.symm_tm
+  case nil => grind [EqSb.terminal]
+  case snoc => grind [cases EnvEqSb, EqSb.snoc, ValEqTm.conv_tp, WfTp.subst_eq]
+
+theorem ValEqTp.tp_uniq {Γ l vA A A'} : ValEqTp Γ l vA A → ValEqTp Γ l vA A' → Γ ⊢[l] A ≡ A' :=
+  fun h h' => uniq_all.1 h h'
+
+theorem ValEqTm.tm_uniq {Γ l vt t t' A} : ValEqTm Γ l vt t A → ValEqTm Γ l vt t' A →
+    Γ ⊢[l] t ≡ t' : A :=
+  fun h h' => uniq_all.2.1 h h'
+
+theorem NeutEqTm.tm_uniq {Γ l vn n A n' A'} : NeutEqTm Γ l vn n A → NeutEqTm Γ l vn n' A' →
+    Γ ⊢[l] n ≡ n' : A :=
+  fun h h' => uniq_all.2.2.1 h h' |>.2
+
+theorem ClosEqTp.tp_uniq {Γ l l' A vB B B'} : ClosEqTp Γ l l' A vB B → ClosEqTp Γ l l' A vB B' →
+    (A, l) :: Γ ⊢[l'] B ≡ B' :=
+  fun h h' => uniq_all.2.2.2.1 h h'
+
+theorem ClosEqTm.tm_uniq {Γ l l' A B vb b b'} : ClosEqTm Γ l l' A B vb b →
+    ClosEqTm Γ l l' A B vb b' → (A, l) :: Γ ⊢[l'] b ≡ b' : B :=
+  fun h h' => uniq_all.2.2.2.2.1 h h'
+
+theorem EnvEqSb.sb_uniq {Δ E σ σ' Γ} : EnvEqSb Δ E σ Γ → EnvEqSb Δ E σ' Γ → EqSb Δ σ σ' Γ :=
+  fun h h' => uniq_all.2.2.2.2.2 h h'


### PR DESCRIPTION
I realized while working on the typechecker that the previous type of values wasn't good enough; I left some `Expr` annotations there, but those use indices instead of levels and consequently don't have free weakening. This PR redoes the evaluator correctness proof in terms of a functional relation between values and expressions. It also proves that weakening is free for the thinned value type.