### PR TITLE
Pseudo+equiv

### DIFF
--- a/GroupoidModel/ForMathlib/CategoryTheory/Functor/Iso.lean
+++ b/GroupoidModel/ForMathlib/CategoryTheory/Functor/Iso.lean
@@ -1,5 +1,6 @@
-import GroupoidModel.ForMathlib
-
+import Mathlib.CategoryTheory.Functor.Category
+import SEq.Tactic.DepRewrite
+import Mathlib.CategoryTheory.Category.ULift
 
 namespace CategoryTheory.Functor
 
@@ -245,7 +246,6 @@ theorem cancel_iso_hom_left (f : X ≅≅ Y) (g g' : Y ⥤ Z) :
   . intro h
     rw[h]
 
-
 @[simp]
 theorem cancel_iso_inv_left (f : Y ≅≅ X) (g g' : Y ⥤ Z) :
     f.inv ⋙ g = f.inv ⋙ g' ↔ g = g' := by
@@ -314,6 +314,13 @@ theorem cancel_iso_inv_right_assoc (f : W ⥤ X) (g : X ⥤ Y) (f' : W ⥤ X')
   . intro hy
     simp only [← Functor.assoc, cancel_iso_inv_right]
     exact hy
+
+def toEquivalence (h : X ≅≅ Y) : X ≌ Y where
+  functor := h.hom
+  inverse := h.inv
+  unitIso := eqToIso h.hom_inv_id.symm
+  counitIso := eqToIso h.inv_hom_id
+  functor_unitIso_comp x := by simp [eqToHom_map]
 
 end Iso
 

--- a/GroupoidModel/Grothendieck/Groupoidal/Basic.lean
+++ b/GroupoidModel/Grothendieck/Groupoidal/Basic.lean
@@ -534,21 +534,21 @@ theorem map_forget (α : F ⟶ G) : map α ⋙ forget = forget :=
   rfl
 
 @[simp] theorem map_obj_base (X) : ((map α).obj X).base = X.base :=
-  Grothendieck.map_obj_base _
+  Grothendieck.map_obj_base _ _
 
 @[simp] theorem map_obj_fiber (X) :
     ((map α).obj X).fiber = (α.app X.base).obj X.fiber :=
-  Grothendieck.map_obj_fiber _
+  Grothendieck.map_obj_fiber _ _
 
 variable {X} {Y : ∫(F)} (f : X ⟶ Y)
 
 @[simp] theorem map_map_base : ((Groupoidal.map α).map f).base = f.base
-    := Grothendieck.map_map_base _
+    := Grothendieck.map_map_base _ _
 
 @[simp] theorem map_map_fiber :
   ((Groupoidal.map α).map f).fiber =
     eqToHom (Functor.congr_obj (α.naturality f.base).symm X.fiber)
-    ≫ (α.app Y.base).map f.fiber := Grothendieck.map_map_fiber _
+    ≫ (α.app Y.base).map f.fiber := Grothendieck.map_map_fiber _ _
 
 end
 

--- a/GroupoidModel/Grothendieck/IsPullback.lean
+++ b/GroupoidModel/Grothendieck/IsPullback.lean
@@ -23,7 +23,7 @@ variable (A)
 
 def toPCat : ∫ A ⥤ PCat.{v₁,u₁} :=
   functorTo (forget _ ⋙ A) (fun x => x.fiber) (fun f => f.fiber)
-    (by simp) (by intros; simp; rfl)
+    (by simp) (by intros; simp)
 
 @[simp] theorem toPCat_obj_base (x) :
     ((toPCat A).obj x).base = A.obj x.base := by

--- a/GroupoidModel/Groupoids/Pi.lean
+++ b/GroupoidModel/Groupoids/Pi.lean
@@ -532,7 +532,9 @@ def strongTrans : (A ⋙ Grpd.forgetToCat).toPseudoFunctor'.StrongTrans
     naturality_comp := sorry
 
 def mapStrongTrans : ∫ A ⥤ ∫ sigma A B :=
-  Pseudofunctor.Grothendieck.map (strongTrans B s hs)
+  Functor.Grothendieck.toPseudoFunctor'Iso.hom _ ⋙
+  Pseudofunctor.Grothendieck.map (strongTrans B s hs) ⋙
+  Functor.Grothendieck.toPseudoFunctor'Iso.inv _
 
 /--  Let `Γ` be a category.
 For any pair of functors `A : Γ ⥤ Grpd` and `B : ∫(A) ⥤ Grpd`,
@@ -542,18 +544,17 @@ there is a "term of `B`" `inversion : Γ ⥤ PGrpd` such that `inversion ⋙ for
 -/
 def inversion : ∫(A) ⥤ PGrpd := mapStrongTrans B s hs ⋙ sigma.assoc B ⋙ toPGrpd B
 
--- TODO: maybe make a lemma for `map (α ≫ β)` for composition of strong transformations?
 lemma mapStrongTrans_comp_fstAux' : mapStrongTrans B s hs ⋙ sigma.fstAux' B = 𝟭 _ := by
   apply Functor.Groupoidal.FunctorTo.hext
-  · simp only [mapStrongTrans, Grpd.forgetToCat.eq_1, sigma.fstAux', Functor.assoc, map_forget,
-      Functor.id_comp]
-    dsimp only [Functor.Groupoidal.forget, Functor.Grothendieck.forget, Grpd.forgetToCat.eq_1]
-    rw [Pseudofunctor.Grothendieck.map_comp_forget]
+  · rw [Functor.assoc, sigma.fstAux', map_forget, mapStrongTrans, Functor.assoc,
+      Functor.assoc, Functor.Groupoidal.forget,
+      Functor.Grothendieck.toPseudoFunctor'Iso.inv_comp_forget,
+      Pseudofunctor.Grothendieck.map_comp_forget, Functor.id_comp,
+      Functor.Grothendieck.toPseudoFunctor'Iso.hom_comp_forget,
+      Functor.Groupoidal.forget]
   · intro x
     simp only [sigma.fstAux', Functor.comp_obj, map_obj_fiber, sigma_obj, sigma.fstAux_app,
       Functor.Groupoidal.forget_obj, Functor.id_obj, heq_eq_eq]
-    simp only [mapStrongTrans, fiber, Functor.Grothendieck.fiber, sigma_obj, strongTrans_app,
-      Pseudofunctor.Grothendieck.map_obj_fiber, Functor.toPseudoFunctor'_obj, Functor.comp_obj]
     exact Functor.congr_obj (PGrpd.objFiber' hs x.base).property x.fiber
   · sorry
 

--- a/GroupoidModel/Pointed/Basic.lean
+++ b/GroupoidModel/Pointed/Basic.lean
@@ -61,7 +61,6 @@ theorem comp_map {C D E : PCat} (F : C ⟶ D) (G : D ⟶ E) {X Y : C.base}
 @[simp] lemma comp_fiber {C D E : PCat} (F : C ⟶ D) (G : D ⟶ E) :
     (F ≫ G).fiber = G⟱.map F.fiber ≫ G.fiber := by
   simp
-  rfl
 
 -- formerly `map_id_point`
 @[simp] theorem map_id_fiber {C : Type u} [Category.{v} C] {F : C ⥤ PCat}
@@ -76,7 +75,6 @@ theorem comp_map {C D E : PCat} (F : C ⟶ D) (G : D ⟶ E) {X Y : C.base}
     eqToHom (by simp) ≫ (F.map g)⟱.map (F.map f).fiber ≫ (F.map g).fiber := by
   rw! [Functor.map_comp]
   simp
-  rfl
 
 /-- This is the proof of equality used in the eqToHom in `PCat.eqToHom_point` -/
 theorem eqToHom_point_aux {P1 P2 : PCat.{v,u}} (eq : P1 = P2) :
@@ -193,7 +191,6 @@ theorem comp_map {C D E : PGrpd} (F : C ⟶ D) (G : D ⟶ E) {X Y : C.base}
 @[simp] lemma comp_fiber {C D E : PGrpd} (F : C ⟶ D) (G : D ⟶ E) :
     (F ≫ G).fiber = G⟱.map F.fiber ≫ G.fiber := by
   simp [forgetToCat]
-  rfl
 
 -- formerly `map_id_point`
 @[simp] theorem map_id_fiber {C : Type u} [Category.{v} C] {F : C ⥤ PGrpd}
@@ -351,7 +348,6 @@ theorem mapFiber'_comp {x y z} (f : x ⟶ y)
     (eqToHom (mapFiber'_comp_aux0 h)).map ((α.map g).base.map (α.map f).fiber)
     ≫ (eqToHom (mapFiber'_comp_aux0 h)).map (α.map g).fiber := by
   simp [mapFiber', eqToHom_map, mapFiber'EqToHom]
-  rfl
 
 theorem mapFiber'_naturality {Δ : Type*} [Category Δ] (σ : Δ ⥤ Γ) {x y} (f : x ⟶ y) :
     @mapFiber' _ _ (σ ⋙ A) (σ ⋙ α) (by rw [Functor.assoc, h]) _ _ f


### PR DESCRIPTION
I have yet again refactored the definition of Grothendieck. The other approach was leading to a huge slowdown. 

In short: Pseudofunctor.Grothendieck is no longer the definition of the 1-functor definition. Instead we define each separately and prove an equivalence.