### PR TITLE
refactor: use typeclasses for UHomSeq extensions 

### DIFF
--- a/GroupoidModel/ForPoly.lean
+++ b/GroupoidModel/ForPoly.lean
@@ -165,8 +165,6 @@ theorem fan_snd_map' {E B E' B' : C} {P : UvPoly E B} {P' : UvPoly E' B'}
   slice_lhs 5 6 => apply pullback.lift_fst
   simp [Over.mapForget]
 
-theorem fan_snd {E B : C} (P : UvPoly E B) (A : C) : (fan P A).snd = ε P A ≫ prod.snd := rfl
-
 open ExponentiableMorphism in
 theorem fan_snd_map {E B A E' B' A' : C} {P : UvPoly E B} {P' : UvPoly E' B'}
     (e : E ⟶ E') (b : B ⟶ B') (a : A ⟶ A')

--- a/GroupoidModel/ForPoly.lean
+++ b/GroupoidModel/ForPoly.lean
@@ -165,6 +165,8 @@ theorem fan_snd_map' {E B E' B' : C} {P : UvPoly E B} {P' : UvPoly E' B'}
   slice_lhs 5 6 => apply pullback.lift_fst
   simp [Over.mapForget]
 
+theorem fan_snd {E B : C} (P : UvPoly E B) (A : C) : (fan P A).snd = ε P A ≫ prod.snd := rfl
+
 open ExponentiableMorphism in
 theorem fan_snd_map {E B A E' B' A' : C} {P : UvPoly E B} {P' : UvPoly E' B'}
     (e : E ⟶ E') (b : B ⟶ B') (a : A ⟶ A')

--- a/GroupoidModel/Groupoids/Pi.lean
+++ b/GroupoidModel/Groupoids/Pi.lean
@@ -1096,10 +1096,8 @@ def uHomSeqPis' (i : ℕ) (ilen : i < 4) :
   | 3 => smallUPi.{3,4}
   | (n+4) => by omega
 
-def uHomSeqPiSigma : UHomSeqPiSig Ctx where
-  __ := uHomSeq
+instance uHomSeqPi : uHomSeq.PiSeq where
   nmPi := uHomSeqPis'
-  nmSig := uHomSeqSigs'
 
 end
 

--- a/GroupoidModel/Groupoids/Sigma.lean
+++ b/GroupoidModel/Groupoids/Sigma.lean
@@ -1005,5 +1005,8 @@ def uHomSeqSigs' (i : ℕ) (ilen : i < 4) :
   | 3 => smallUSig.{3, 4}
   | (n+4) => by omega
 
+instance uHomSeqSigma : uHomSeq.SigSeq where
+  nmSig := uHomSeqSigs'
+
 end GroupoidModel
 end

--- a/GroupoidModel/Syntax/Interpretation.lean
+++ b/GroupoidModel/Syntax/Interpretation.lean
@@ -686,7 +686,7 @@ theorem mem_ofType_ofTerm_subst' {full}
     | snoc' _ _ _ _ _ _ _ ih1 =>
       induction i with
       | zero =>
-        obtain ⟨rfl, H⟩ := mem_var_zero.1 H
+        obtain ⟨rfl, H⟩ := CObj.mem_var_zero.1 H
         simp at H; subst H; simpa
       | succ i ih2 =>
         obtain ⟨_, H', rfl⟩ := CObj.mem_var_succ.1 H
@@ -797,9 +797,11 @@ theorem var_sound {Γ i A l} (H : Lookup Γ i A l) {sΓ} (hΓ : sΓ ∈ ofCtx s 
   obtain ⟨_, h1, rfl⟩ := h1
   exact ⟨llen, _, h1, h2⟩
 
+attribute [local irreducible] IsKernelPair.lift IsPullback.isLimit CategoryStruct.comp
+  Quiver.Hom yoneda mkId
 -- TODO: this proof is boring, repetitive exists-elim/exists-intro: automate!
 include slen in
-set_option maxHeartbeats 700000 in
+set_option maxHeartbeats 1600000 in
 theorem ofType_ofTerm_sound :
     (∀ {Γ}, WfCtx Γ → (ofCtx s Γ).Dom) ∧
     (∀ {Γ l A}, (Awf : Γ ⊢[l] A) → ∃ sΓ ∈ ofCtx s Γ, ∃ llen,
@@ -814,18 +816,18 @@ theorem ofType_ofTerm_sound :
   simp [Part.dom_iff_mem]
   mutual_induction WfCtx
 
-  case nil => simp
-  case snoc =>
+  case nil => as_aux_lemma => simp
+  case snoc => as_aux_lemma =>
     simp only [mem_ofCtx_snoc, forall_exists_index, and_imp]
     intros; rename_i hΓ llen _ hA
     exact ⟨_, _, hΓ, llen, _, hA, rfl⟩
 
-  case pi' | sigma' =>
+  case pi' | sigma' => as_aux_lemma =>
     simp only [mem_ofCtx_snoc, mem_ofType_pi, mem_ofType_sigma,
       sup_lt_iff, exists_true_left, forall_exists_index, and_imp]
     intros; subst_eqs
     exact ⟨_, ‹_›, ⟨‹_›, ‹_›⟩, _, _, ‹_›, _, ‹_›, rfl⟩
-  case Id' =>
+  case Id' => as_aux_lemma =>
     simp only [mem_ofType_Id, forall_exists_index, and_imp]
     intros; subst_eqs; rename_i hΓ _ _ hA _ hΓ' _ _ _ _ hΓ₁ _ _ _ hA₁ hA₂
     cases Part.mem_unique hΓ hΓ'
@@ -833,23 +835,23 @@ theorem ofType_ofTerm_sound :
     have := Part.mem_unique hA₁ hA
     have := Part.mem_unique hA₂ hA
     exact ⟨_, ‹_›, ‹_›, _, _, hA, _, ‹_›, _, ‹_›, ‹_›, ‹_›, rfl⟩
-  case univ =>
+  case univ => as_aux_lemma =>
     simp only [mem_ofType_univ, exists_true_left, forall_exists_index]
     intros; rename_i hΓ
     exact ⟨_, hΓ, by omega, _, rfl⟩
-  case el =>
+  case el => as_aux_lemma =>
     simp only [mem_ofType_univ, mem_ofType_el, forall_exists_index, and_imp]
     intros; subst_eqs
     exact ⟨_, ‹_›, by omega, _, by omega, _, ‹_›, ‹_›, rfl⟩
 
-  case cong_pi' | cong_sigma' =>
+  case cong_pi' | cong_sigma' => as_aux_lemma =>
     simp only [mem_ofCtx_snoc, mem_ofType_pi, mem_ofType_sigma,
       forall_exists_index, and_imp, exists_true_left, sup_lt_iff]
     intros; subst_eqs; rename_i hΓ _ _ hA _ _ hΓ' _ _ hA' _ _ _ _
     cases Part.mem_unique hΓ hΓ'
     cases Part.mem_unique hA hA'
     exact ⟨_, hΓ, ⟨‹_›, ‹_›⟩, _, ⟨_, hA, _, ‹_›, rfl⟩, ⟨_, ‹_›, _, ‹_›, rfl⟩⟩
-  case cong_Id =>
+  case cong_Id => as_aux_lemma =>
     simp only [mem_ofType_Id, forall_exists_index, and_imp]
     intros; subst_eqs; rename_i hΓ _ _ hA hA' _ hΓ' _ _ _ _ _ hΓ₁ _ _ _ _ hA₁ hA₂
     cases Part.mem_unique hΓ hΓ'
@@ -858,31 +860,31 @@ theorem ofType_ofTerm_sound :
     have := Part.mem_unique hA₂ hA
     exact ⟨_, hΓ, ‹_›, _,
       ⟨_, hA, _, ‹_›, _, ‹_›, ‹_›, ‹_›, rfl⟩, ⟨_, hA', _, ‹_›, _, ‹_›, ‹_›, ‹_›, rfl⟩⟩
-  case cong_el =>
+  case cong_el => as_aux_lemma =>
     simp only [mem_ofType_univ, mem_ofType_el, forall_exists_index, and_imp]
     intros; subst_eqs
     exact ⟨_, ‹_›, by omega, _, ⟨by omega, _, ‹_›, ‹_›, rfl⟩, ⟨by omega, _, ‹_›, ‹_›, rfl⟩⟩
-  case el_code =>
+  case el_code => as_aux_lemma =>
     simp only [mem_ofTerm_code, mem_ofType_el, forall_exists_index, and_imp,
       Nat.add_right_cancel_iff, exists_prop_eq']
     intros
     refine ⟨_, ‹_›, ‹_›, _, ⟨by omega, _, ⟨_, ‹_›, rfl⟩, ?_, rfl⟩, ?_⟩
     · apply s.code_tp
     · rwa [s.el_code]
-  case refl_tp | symm_tp => grind
-  case trans_tp =>
+  case refl_tp | symm_tp => as_aux_lemma => grind
+  case trans_tp => as_aux_lemma =>
     simp only [forall_exists_index, and_imp]
     intros; rename_i hΓ _ _ _ hA₁ _ hΓ' _ _ hA₂ _
     cases Part.mem_unique hΓ hΓ'
     cases Part.mem_unique hA₁ hA₂
     exact ⟨_, ‹_›, ‹_›, _, ‹_›, ‹_›⟩
 
-  case bvar =>
+  case bvar => as_aux_lemma =>
     simp only [ofTerm_bvar, forall_exists_index]
     intros
     obtain ⟨llen, _, h1, h2⟩ := var_sound ‹_› ‹_›
     exact ⟨_, ‹_›, llen, _, h2, _, h1, rfl⟩
-  case lam' =>
+  case lam' => as_aux_lemma =>
     simp only [mem_ofCtx_snoc, mem_ofTerm_lam, mem_ofType_pi,
       sup_lt_iff, forall_exists_index, and_imp, exists_true_left]
     intros; subst_eqs; rename_i hΓ _ _ hA _ hΓ' _ _ hA' _ _ _ _
@@ -890,7 +892,7 @@ theorem ofType_ofTerm_sound :
     cases Part.mem_unique hA hA'
     refine ⟨_, ‹_›, ⟨‹_›, ‹_›⟩, _, ⟨_, ‹_›, _, ‹_›, rfl⟩, _, ⟨_, ‹_›, _, ‹_›, rfl⟩, ?_⟩
     apply mkLam_tp (t_tp := rfl)
-  case app' =>
+  case app' => as_aux_lemma =>
     simp only [mem_ofCtx_snoc, mem_ofTerm_app, mem_ofType_pi,
       sup_lt_iff, forall_exists_index, and_imp, exists_true_left]
     intros; subst_eqs
@@ -904,7 +906,7 @@ theorem ofType_ofTerm_sound :
     refine ⟨_, ‹_›, ‹_›, _, ?_, _, ⟨‹_›, _, ‹_›, _, ‹_›, _, rfl, _, ‹_›, ‹_›, rfl⟩, rfl⟩
     rw [mkApp_tp]
     apply mem_ofType_toSb <;> assumption
-  case pair' =>
+  case pair' => as_aux_lemma =>
     simp only [mem_ofCtx_snoc, mem_ofTerm_pair, mem_ofType_sigma,
       sup_lt_iff, forall_exists_index, and_imp, exists_true_left]
     intros; subst_eqs
@@ -919,7 +921,7 @@ theorem ofType_ofTerm_sound :
     · apply mkPair_tp
     · refine Part.mem_unique ‹_› ?_
       apply mem_ofType_toSb <;> assumption
-  case fst' =>
+  case fst' => as_aux_lemma =>
     simp only [mem_ofCtx_snoc, mem_ofTerm_fst, mem_ofType_sigma,
       sup_lt_iff, forall_exists_index, and_imp, exists_true_left]
     intros; subst_eqs; rename_i hΓ _ _ hA _ hΓ' _ _ hA' _ _ hΓ₁ _ _ hA₁ _ hB _ _ _ hB' _
@@ -930,7 +932,7 @@ theorem ofType_ofTerm_sound :
     cases Part.mem_unique hB hB'; clear hB'
     refine ⟨_, ‹_›, ‹_›, _, ‹_›, _, ⟨‹_›, _, ‹_›, _, ‹_›, _, ‹_›, ‹_›, rfl⟩, ?_⟩
     apply mkFst_tp
-  case snd' =>
+  case snd' => as_aux_lemma =>
     simp only [mem_ofCtx_snoc, mem_ofTerm_snd, mem_ofType_sigma,
       sup_lt_iff, forall_exists_index, and_imp, exists_true_left]
     intros; subst_eqs; rename_i hΓ _ _ hA _ hΓ' _ _ hA' _ _ hΓ₁ _ _ hA₁ _ hB _ _ _ hB' _
@@ -943,18 +945,18 @@ theorem ofType_ofTerm_sound :
     rw [mkSnd_tp]
     apply mem_ofType_toSb <;> simp only [mem_ofTerm_fst, exists_true_left, *]
     exact ⟨_, ‹_›, _, ‹_›, _, ‹_›, ‹_›, rfl⟩
-  case refl' =>
+  case refl' => as_aux_lemma =>
     simp only [mem_ofTerm_refl, mem_ofType_Id, forall_exists_index, and_imp]
     intros; subst_eqs
     refine ⟨_, ‹_›, ‹_›, _, ⟨_, ‹_›, _, ‹_›, _, ‹_›, rfl, rfl, rfl⟩, _, ⟨_, ‹_›, rfl⟩, ?_⟩
     apply mkRefl_tp
-  case idRec' =>
-    simp only [mem_ofCtx_snoc, mem_ofTerm_idRec, mem_ofType_Id,
+  case idRec' => as_aux_lemma =>
+    simp only [mem_ofCtx_snoc, mem_ofTerm_idRec, mem_ofType_Id, ofTerm_bvar,
       forall_exists_index, and_imp]
     intros; subst_eqs
     rename_i t' _ _ _ i _ _ _ _ _ _ _ _
       hΓ ilen A hA _ hΓ' _ t ht _ hΓ₁ _ _ hA₁ _ _ _ hΓ₂ llen r hr _ hΓ₃ _ u hu _ hΓ₄
-      _ _ ht₁ _ hu₁ h hh _ _ _ _ _ rtp hA₂ hA₃ utp _ _ _ M hM
+      _ _ ht₁ _ hu₁ h hh _ _ _ _ hv rtp hA₂ hA₃ utp _ _ _ M hM
     cases Part.mem_unique hΓ hΓ'
     cases Part.mem_unique hΓ hΓ₁
     cases Part.mem_unique hA hA₁
@@ -964,8 +966,10 @@ theorem ofType_ofTerm_sound :
     cases Part.mem_unique ht ht₁
     cases Part.mem_unique hu hu₁
     cases Part.mem_unique hA₃ hA
-    refine ⟨_, ‹_›, ‹_›, _, ?_, _, ⟨‹_›, _, ‹_›, _, rfl, _, rfl,
-      M, by convert hM using 1, _, ‹_›, ?_, _, ‹_›, ‹_›, _, ‹_›, ‹_›, rfl⟩, rfl⟩
+    cases Part.mem_unique (mem_ofTerm_wk ilen ht) ‹_›
+    simp only [CObj.mem_var_zero, exists_const] at hv; subst hv
+    refine ⟨_, ‹_›, ‹_›, _, ?_, _, ⟨‹_›, _, ‹_›, _, _, _, by simp,
+      M, hM, _, ‹_›, ?_, _, ‹_›, ‹_›, _, ‹_›, ‹_›, rfl⟩, rfl⟩
     · rw [mkIdRec_tp]
       refine (s.mem_ofType_ofTerm_subst llen (.snoc (.sub1 _ _ _ utp hu) _ _ _ ?_ hh) ?_).1 hM
       simp [*]
@@ -974,14 +978,14 @@ theorem ofType_ofTerm_sound :
         (.snoc (.sub1 _ _ _ rfl ht) _ _ (.refl i t') ?_ ?_) ?_).1 hM
       · exact mem_ofTerm_refl.2 ⟨_, ht, rfl⟩
       · rfl
-  case code =>
+  case code => as_aux_lemma =>
     simp only [mem_ofTerm_code, mem_ofType_univ,
       Nat.add_right_cancel_iff, exists_prop_eq', exists_eq_left, Nat.add_lt_add_iff_right,
       forall_exists_index, and_imp, exists_true_left]
     intros
     refine ⟨_, ‹_›, by omega, _, ⟨_, ‹_›, rfl⟩, ?_⟩
     apply UHomSeq.code_tp
-  case conv =>
+  case conv => as_aux_lemma =>
     simp only [forall_exists_index, and_imp]
     intros; subst_eqs
     rename_i hΓ _ _ _ _ hΓ' _ _ hA _ hA'
@@ -989,7 +993,7 @@ theorem ofType_ofTerm_sound :
     cases Part.mem_unique hA hA'; clear hA'
     exact ⟨_, ‹_›, ‹_›, _, ‹_›, _, ‹_›, rfl⟩
 
-  case cong_lam' =>
+  case cong_lam' => as_aux_lemma =>
     simp only [mem_ofCtx_snoc, mem_ofTerm_lam, mem_ofType_pi,
       sup_lt_iff, forall_exists_index, and_imp, exists_true_left]
     intros; subst_eqs; rename_i hΓ _ _ hA _ hΓ' _ _ hA' _ hΓ₁ _ _ hA₁ hA'₁ _ hΓ₂ _ _ hA₂ _ _ _ _ _
@@ -1002,7 +1006,7 @@ theorem ofType_ofTerm_sound :
     refine ⟨_, ‹_›, ⟨‹_›, ‹_›⟩, _, ⟨_, ‹_›, _, ‹_›, rfl⟩, _,
       ⟨_, ‹_›, _, ‹_›, rfl⟩, ⟨_, ‹_›, _, ‹_›, rfl⟩, ?_⟩
     apply mkLam_tp (t_tp := rfl)
-  case cong_app' =>
+  case cong_app' => as_aux_lemma =>
     simp only [mem_ofCtx_snoc, mem_ofTerm_app, mem_ofType_pi,
       sup_lt_iff, forall_exists_index, and_imp, exists_true_left]
     intros; subst_eqs
@@ -1018,7 +1022,7 @@ theorem ofType_ofTerm_sound :
       ⟨‹_›, _, ‹_›, _, ‹_›, _, rfl, _, ‹_›, ‹_›, rfl⟩, rfl⟩
     rw [mkApp_tp]
     apply mem_ofType_toSb <;> assumption
-  case cong_pair' =>
+  case cong_pair' => as_aux_lemma =>
     simp only [mem_ofCtx_snoc, mem_ofTerm_pair, mem_ofType_sigma,
       sup_lt_iff, forall_exists_index, and_imp, exists_true_left]
     intros; subst_eqs
@@ -1033,7 +1037,7 @@ theorem ofType_ofTerm_sound :
     · apply mkPair_tp
     · refine Part.mem_unique ‹_› ?_
       apply mem_ofType_toSb <;> assumption
-  case cong_fst' =>
+  case cong_fst' => as_aux_lemma =>
     simp only [mem_ofCtx_snoc, mem_ofTerm_fst, mem_ofType_sigma,
       sup_lt_iff, forall_exists_index, and_imp, exists_true_left]
     intros; subst_eqs
@@ -1048,7 +1052,7 @@ theorem ofType_ofTerm_sound :
     refine ⟨_, ‹_›, ‹_›, _, ‹_›, _, ⟨‹_›, _, ‹_›, _, ‹_›, _, ‹_›, ‹_›, rfl⟩,
       ⟨‹_›, _, ‹_›, _, ‹_›, _, ‹_›, ‹_›, rfl⟩, ?_⟩
     apply mkFst_tp
-  case cong_snd' =>
+  case cong_snd' => as_aux_lemma =>
     simp only [mem_ofCtx_snoc, mem_ofTerm_snd, mem_ofType_sigma,
       sup_lt_iff, forall_exists_index, and_imp, exists_true_left]
     intros; subst_eqs
@@ -1065,19 +1069,19 @@ theorem ofType_ofTerm_sound :
     rw [mkSnd_tp]
     apply mem_ofType_toSb <;> simp only [mem_ofTerm_fst, exists_true_left, *]
     exact ⟨_, ‹_›, _, ‹_›, _, ‹_›, ‹_›, rfl⟩
-  case cong_refl' =>
+  case cong_refl' => as_aux_lemma =>
     simp only [mem_ofTerm_refl, mem_ofType_Id, forall_exists_index, and_imp]
     intros; subst_eqs
     refine ⟨_, ‹_›, ‹_›, _, ⟨_, ‹_›, _, ‹_›, _, ‹_›, rfl, rfl, rfl⟩, _,
       ⟨_, ‹_›, rfl⟩, ⟨_, ‹_›, rfl⟩, ?_⟩
     apply mkRefl_tp
-  case cong_idRec' =>
-    simp only [mem_ofCtx_snoc, mem_ofTerm_idRec, mem_ofType_Id,
+  case cong_idRec' => as_aux_lemma =>
+    simp only [mem_ofCtx_snoc, mem_ofTerm_idRec, mem_ofType_Id, ofTerm_bvar,
       forall_exists_index, and_imp]
     intros; subst_eqs
     rename_i et _ _ _ _ _ _ _ i _ _ _ _ _ _ _ _ _
       hΓ ilen A hA _ hΓ' _ t ht _ hΓ₁ _ _ ht₁ _ _ hΓ₂ _ _ hA₁ _ llen _ hΓ₃ u _ hr _ _ hΓ₄ _ _
-      hu _ _ hΓ₅ _ _ ht₂ _ hu₁ _ hh hh' _ _ _ _ _ _ rtp hA₂ hA₃ utp _ _ _ M hM hM'
+      hu _ _ hΓ₅ _ _ ht₂ _ hu₁ _ hh hh' _ _ _ _ _ hv rtp hA₂ hA₃ utp _ _ _ M hM hM'
     cases Part.mem_unique hΓ hΓ'
     cases Part.mem_unique hΓ hΓ₁
     cases Part.mem_unique hΓ hΓ₂
@@ -1089,11 +1093,11 @@ theorem ofType_ofTerm_sound :
     cases Part.mem_unique ht ht₂
     cases Part.mem_unique hu hu₁
     cases Part.mem_unique hA₃ hA
+    cases Part.mem_unique (mem_ofTerm_wk ilen ht) ‹_›
+    simp only [CObj.mem_var_zero, exists_const] at hv; subst hv
     refine ⟨_, ‹_›, ‹_›, _, ?_, _,
-      ⟨‹_›, _, ‹_›, _, rfl, _, rfl, M, by convert hM using 1,
-        _, ‹_›, ?h3, _, ‹_›, ‹_›, _, ‹_›, ‹_›, rfl⟩,
-      ⟨‹_›, _, ‹_›, _, rfl, _, rfl, M, by convert hM' using 1,
-        _, ‹_›, ?h3, _, ‹_›, ‹_›, _, ‹_›, ‹_›, rfl⟩, rfl⟩
+      ⟨‹_›, _, ‹_›, _, rfl, _, by simp, M, hM, _, ‹_›, ?h3, _, ‹_›, ‹_›, _, ‹_›, ‹_›, rfl⟩,
+      ⟨‹_›, _, ‹_›, _, rfl, _, by simp, M, hM', _, ‹_›, ?h3, _, ‹_›, ‹_›, _, ‹_›, ‹_›, rfl⟩, rfl⟩
     · rw [mkIdRec_tp]
       refine (s.mem_ofType_ofTerm_subst llen (.snoc (.sub1 _ _ _ utp hu) _ _ _ ?_ hh) ?_).1 hM
       simp [*]
@@ -1102,14 +1106,14 @@ theorem ofType_ofTerm_sound :
         (.snoc (.sub1 _ _ _ rfl ht) _ _ (.refl i et) ?_ ?_) ?_).1 hM
       · exact mem_ofTerm_refl.2 ⟨_, ht, rfl⟩
       · rfl
-  case cong_code =>
+  case cong_code => as_aux_lemma =>
     simp only [mem_ofTerm_code, mem_ofType_univ,
       Nat.add_right_cancel_iff, exists_prop_eq', exists_eq_left, Nat.add_lt_add_iff_right,
       forall_exists_index, and_imp, exists_true_left]
     intros
     refine ⟨_, ‹_›, by omega, _, ⟨_, ‹_›, rfl⟩, ⟨_, ‹_›, rfl⟩, ?_⟩
     apply UHomSeq.code_tp
-  case app_lam' =>
+  case app_lam' => as_aux_lemma =>
     simp only [mem_ofCtx_snoc, mem_ofTerm_app, mem_ofTerm_lam,
       forall_exists_index, and_imp, exists_true_left]
     intros; subst_eqs
@@ -1128,7 +1132,7 @@ theorem ofType_ofTerm_sound :
     · apply mkLam_tp (t_tp := rfl)
     · rw [mkApp_mkLam (t_tp := rfl)]
       apply mem_ofTerm_toSb <;> assumption
-  case fst_pair' =>
+  case fst_pair' => as_aux_lemma =>
     simp only [mem_ofCtx_snoc, mem_ofTerm_fst, mem_ofTerm_pair,
       forall_exists_index, and_imp, exists_true_left]
     intros; subst_eqs
@@ -1145,7 +1149,7 @@ theorem ofType_ofTerm_sound :
     · apply mkPair_tp
     · rwa [mkFst_mkPair]
     · rw [mkFst_mkPair]
-  case snd_pair' =>
+  case snd_pair' => as_aux_lemma =>
     simp only [mem_ofCtx_snoc, mem_ofTerm_snd, mem_ofTerm_pair,
       forall_exists_index, and_imp, exists_true_left]
     intros; subst_eqs
@@ -1162,26 +1166,28 @@ theorem ofType_ofTerm_sound :
       apply mem_ofType_toSb <;> assumption
     · apply mkPair_tp
     · rwa [mkSnd_mkPair]
-  case idRec_refl' =>
-    simp only [mem_ofCtx_snoc, mem_ofTerm_idRec, mem_ofTerm_refl, mem_ofType_Id,
+  case idRec_refl' => as_aux_lemma =>
+    simp only [mem_ofCtx_snoc, mem_ofTerm_idRec, mem_ofTerm_refl, mem_ofType_Id, ofTerm_bvar,
       forall_exists_index, and_imp]
     intros; subst_eqs
     rename_i et _ i _ _ _ _ _ _ hΓ ilen _ hA _ hΓ' _ _ ht _ hΓ₁ _ _ hA₁ _ llen _ hΓ₂
-      _ _ hr hA₂ _ _ _ _ rtp _ utp M hM
+      _ _ hr hA₂ _ _ _ hv rtp _ utp M hM
     cases Part.mem_unique hΓ hΓ'
     cases Part.mem_unique hΓ hΓ₁
     cases Part.mem_unique hΓ hΓ₂
     cases Part.mem_unique hA hA₁
     cases Part.mem_unique hA hA₂
+    cases Part.mem_unique (mem_ofTerm_wk ilen ht) ‹_›
+    simp only [CObj.mem_var_zero, exists_const] at hv; subst hv
     refine ⟨_, ‹_›, ‹_›, _, ‹_›, _,
-      ⟨‹_›, _, ‹_›, _, rfl, _, rfl, M, by convert hM using 1, _, ‹_›, ?_,
+      ⟨‹_›, _, ‹_›, _, rfl, _, by simp, M, hM, _, ‹_›, ?_,
         _, ‹_›, rfl, _, ⟨_, ‹_›, rfl⟩, by simp⟩, ‹_›, rfl⟩
     refine Part.mem_unique rtp ?_
     refine (s.mem_ofType_ofTerm_subst llen
       (.snoc (.sub1 _ _ _ rfl ht) _ _ (.refl i et) ?_ ?_) ?_).1 hM
     · exact mem_ofTerm_refl.2 ⟨_, ht, rfl⟩
     · rfl
-  case lam_app' =>
+  case lam_app' => as_aux_lemma =>
     simp only [mem_ofCtx_snoc, mem_ofTerm_app, mem_ofTerm_lam, mem_ofType_pi, ofTerm_bvar,
       sup_lt_iff, forall_exists_index, and_imp, exists_true_left]
     intros; subst_eqs
@@ -1192,14 +1198,12 @@ theorem ofType_ofTerm_sound :
     cases Part.mem_unique hA hA₂; clear hA₂
     cases Part.mem_unique hB hB₁; clear hB₁
     refine ⟨_, ‹_›, ‹_›, _, ⟨_, ‹_›, _, ‹_›, ‹_›⟩, _, ‹_›, ⟨_, ‹_›, _,
-      ⟨‹_›, _, mem_ofTerm_wk _ ‹_› .., _, (CObj.mem_var_zero (x := s[l].var _)).2 ⟨rfl, rfl⟩, _, rfl,
-        _, (mem_ofType_ofTerm_subst _ (.up (.wk _ _) _ _ _ ?_) (CSb.up_toSb _)).1 ‹_›, ?_, ?_⟩,
-      .symm (etaExpand_eq (f_tp := ‹_›) ..)⟩, rfl⟩
+      ⟨‹_›, _, mem_ofTerm_wk _ ‹_› .., _, (CObj.mem_var_zero (x := s[l].var _)).2 ⟨rfl, rfl⟩, _, _,
+        _, (mem_ofType_ofTerm_subst _ (.up (.wk _ _) _ _ _ ?_) (CSb.up_toSb _)).1 ‹_›, ?_, rfl⟩,
+      .symm (s.etaExpand_eq (f_tp := ‹_›) ..)⟩, rfl⟩
     · simp
     · simp [*, comp_mkPi, substWk]
-      congr! 1 <;> [simp; congr!]
-    · simp [substWk]; congr!
-  case pair_fst_snd' =>
+  case pair_fst_snd' => as_aux_lemma =>
     simp only [mem_ofCtx_snoc, mem_ofTerm_pair, mem_ofTerm_fst, mem_ofTerm_snd, mem_ofType_sigma,
       sup_lt_iff, forall_exists_index, and_imp, exists_true_left]
     intros; subst_eqs
@@ -1213,25 +1217,25 @@ theorem ofType_ofTerm_sound :
       ⟨_, ⟨‹_›, _, ‹_›, _, ‹_›, _, ‹_›, ‹_›, rfl⟩, A, by simp, _, ‹_›,
         _, ⟨‹_›, _, ‹_›, _, ‹_›, _, ‹_›, ‹_›, rfl⟩, by simp, ?_⟩, rfl⟩
     exact (mkPair_mkFst_mkSnd (p_tp := ‹_›) ..).symm
-  case code_el =>
+  case code_el => as_aux_lemma =>
     simp only [mem_ofType_univ, mem_ofTerm_code, mem_ofType_el,
       exists_const, exists_eq_left, Nat.add_lt_add_iff_right,
       Nat.add_right_cancel_iff, exists_prop_eq', forall_exists_index, and_imp]
     intros
     refine ⟨_, ‹_›, ‹_›, _, ‹_›, ⟨_, ⟨_, _, ‹_›, ‹_›, rfl⟩, ?_⟩, ‹_›⟩
     rw [UHomSeq.code_el]
-  case conv_eq =>
+  case conv_eq => as_aux_lemma =>
     rintro _ _ _ _ _ _ _ _ ⟨_, hΓ, _, _, hA, _, _, _, rfl⟩ ⟨_, hΓ', _, _, hA', _⟩
     cases Part.mem_unique hΓ hΓ'
     cases Part.mem_unique hA hA'
     exact ⟨_, ‹_›, ‹_›, _, ‹_›, _, ‹_›, ‹_›, rfl⟩
-  case refl_tm =>
+  case refl_tm => as_aux_lemma =>
     rintro _ _ _ _ _ ⟨_, _, _, _, _, _, _, _⟩
     exact ⟨_, ‹_›, ‹_›, _, ‹_›, _, ‹_›, ‹_›, ‹_›⟩
-  case symm_tm' =>
+  case symm_tm' => as_aux_lemma =>
     rintro _ _ _ _ _ _ _ _ ⟨_, _, _, _, _, _, _, _, _⟩
     exact ⟨_, ‹_›, ‹_›, _, ‹_›, _, ‹_›, ‹_›, ‹_›⟩
-  case trans_tm' =>
+  case trans_tm' => as_aux_lemma =>
     rintro _ _ _ _ _ _ _ _ _ _ ⟨_, hΓ, _, _, _, _, _, ht₁, _⟩ ⟨_, hΓ', _, _, _, _, ht₂, _, _⟩
     cases Part.mem_unique hΓ hΓ'
     cases Part.mem_unique ht₁ ht₂

--- a/GroupoidModel/Syntax/UHom.lean
+++ b/GroupoidModel/Syntax/UHom.lean
@@ -405,7 +405,7 @@ variable {i j : Nat} (ilen : i < s.length + 1) (jlen : j < s.length + 1)
 
 /-! ## Pi -/
 
-/-- The data of type and term formers at each universe `s[i].tp`.
+/-- The data of `Pi` and `lam` formers at each universe `s[i].tp`.
 
 This data is universe-monomorphic,
 but we can use it to construct universe-polymorphic formation
@@ -627,6 +627,7 @@ end Pi
 
 /-! ## Sigma -/
 
+/-- The data of `Sig` and `pair` formers at each universe `s[i].tp`.
 class SigSeq (s : UHomSeq Ctx) where
   nmSig (i : Nat) (ilen : i < s.length + 1 := by get_elem_tactic) : NaturalModel.Sigma s[i]
 

--- a/GroupoidModel/Syntax/UHom.lean
+++ b/GroupoidModel/Syntax/UHom.lean
@@ -2,6 +2,7 @@ import GroupoidModel.Syntax.NaturalModel
 import GroupoidModel.ForMathlib
 import Mathlib.CategoryTheory.Limits.Shapes.StrictInitial
 import GroupoidModel.ForPoly
+import GroupoidModel.Tactic.PrintSorries
 
 /-! Morphisms of natural models, and Russell-universe embeddings. -/
 
@@ -399,7 +400,11 @@ lemma code_el (s : UHomSeq Ctx) {Γ : Ctx} {i : Nat} (ilen : i < s.length)
     code s ilen (el s ilen a a_tp) = a := by
   simp [code, el]
 
-end UHomSeq
+-- Sadly, we have to spell out `ilen` and `jlen` due to
+-- https://leanprover.zulipchat.com/#narrow/stream/270676-lean4/topic/Optional.20implicit.20argument
+variable {i j : Nat} (ilen : i < s.length + 1) (jlen : j < s.length + 1)
+
+/-! ## Pi -/
 
 /-- The data of type and term formers at each universe `s[i].tp`.
 
@@ -418,35 +423,19 @@ can be extended to
 --------------------------
 Γ ⊢ₘₐₓ₍ᵢ,ⱼ₎ ΠA. B type
 ``` -/
-structure UHomSeqPiSig (Ctx : Type u) [SmallCategory.{u} Ctx] [CartesianMonoidalCategory Ctx]
-    extends UHomSeq Ctx where
-  nmPi (i : Nat) (ilen : i < length + 1 := by get_elem_tactic) : NaturalModel.Pi toUHomSeq[i]
-  nmSig (i : Nat) (ilen : i < length + 1 := by get_elem_tactic) : NaturalModel.Sigma toUHomSeq[i]
+protected class PiSeq (s : UHomSeq Ctx) where
+  nmPi (i : Nat) (ilen : i < s.length + 1 := by get_elem_tactic) : NaturalModel.Pi s[i]
 
-namespace UHomSeqPiSig
+section Pi
+open PiSeq
 
-variable {Ctx : Type u} [SmallCategory.{u} Ctx] [CartesianMonoidalCategory Ctx]
-
-instance : GetElem (UHomSeqPiSig Ctx) Nat (NaturalModel Ctx)
-    (fun s i => i < s.length + 1) where
-  getElem s i h := s.toUHomSeq[i]
-
-variable (s : UHomSeqPiSig Ctx)
-
-@[simp]
-theorem getElem_toUHomSeq (i : Nat) (ilen : i < s.length + 1) : s.toUHomSeq[i] = s[i] := rfl
-
--- Sadly, we have to spell out `ilen` and `jlen` due to
--- https://leanprover.zulipchat.com/#narrow/stream/270676-lean4/topic/Optional.20implicit.20argument
-variable {i j : Nat} (ilen : i < s.length + 1) (jlen : j < s.length + 1)
-
-/-! ## Pi -/
+variable [s.PiSeq]
 
 def Pi : s[i].Ptp.obj s[j].Ty ⟶ s[max i j].Ty :=
-  s.cartesianNatTransTy i (max i j) j (max i j) ≫ (s.nmPi (max i j)).Pi
+  s.cartesianNatTransTy i (max i j) j (max i j) ≫ (nmPi (max i j)).Pi
 
 def lam : s[i].Ptp.obj s[j].Tm ⟶ s[max i j].Tm :=
-  s.cartesianNatTransTm i (max i j) j (max i j) ≫ (s.nmPi (max i j)).lam
+  s.cartesianNatTransTm i (max i j) j (max i j) ≫ (nmPi (max i j)).lam
 
 def Pi_pb :
     IsPullback (s.lam ilen jlen) (s[i].Ptp.map s[j].tp) s[max i j].tp (s.Pi ilen jlen) := by
@@ -460,7 +449,7 @@ def Pi_pb :
       (s[max i j].Ptp.map (s.homOfLe j (max i j)).mapTy) :=
     CategoryTheory.UvPoly.preservesPullbacks s[max i j].uvPolyTp _ _ _ _
     (s.homOfLe j (max i j)).pb
-  have q := IsPullback.paste_horiz pbB (s.nmPi (max i j)).Pi_pullback
+  have q := IsPullback.paste_horiz pbB (nmPi (max i j)).Pi_pullback
   apply CategoryTheory.IsPullback.paste_horiz (p1 s[j].tp).flip q
 
 /--
@@ -635,10 +624,19 @@ theorem mkApp_mkLam {Γ : Ctx} (A : y(Γ) ⟶ s[i].Ty) (B : y(s[i].ext A) ⟶ s[
   rw [mkApp, unLam_mkLam]
   assumption
 
+end Pi
+
 /-! ## Sigma -/
 
+class SigSeq (s : UHomSeq Ctx) where
+  nmSig (i : Nat) (ilen : i < s.length + 1 := by get_elem_tactic) : NaturalModel.Sigma s[i]
+
+section Sigma
+open SigSeq
+variable [s.SigSeq]
+
 def Sig : s[i].Ptp.obj s[j].Ty ⟶ s[max i j].Ty :=
-  s.cartesianNatTransTy i (max i j) j (max i j) ≫ (s.nmSig (max i j)).Sig
+  s.cartesianNatTransTy i (max i j) j (max i j) ≫ (nmSig (max i j)).Sig
 
 def pair : UvPoly.compDom s[i].uvPolyTp s[j].uvPolyTp ⟶ s[max i j].Tm :=
   let l : s[i].uvPolyTp.compDom s[j].uvPolyTp ⟶ s[max i j].uvPolyTp.compDom s[max i j].uvPolyTp :=
@@ -649,13 +647,13 @@ def pair : UvPoly.compDom s[i].uvPolyTp s[j].uvPolyTp ⟶ s[max i j].Tm :=
       (s.homOfLe j (max i j)).mapTy
       (s.homOfLe i (max i j)).pb.flip
       (s.homOfLe j (max i j)).pb.flip
-  l ≫ (s.nmSig (max i j)).pair
+  l ≫ (nmSig (max i j)).pair
 
 def Sig_pb : IsPullback
     (s.pair ilen jlen)
   (s[i].uvPolyTp.comp s[j].uvPolyTp).p s[max i j].tp
     (s.Sig ilen jlen) :=
-  (UvPoly.compDomMap_isPullback ..).paste_horiz (s.nmSig (max i j)).Sig_pullback
+  (UvPoly.compDomMap_isPullback ..).paste_horiz (nmSig (max i j)).Sig_pullback
 
 /--
 ```
@@ -784,6 +782,8 @@ theorem mkPair_mkFst_mkSnd {Γ : Ctx} (A : y(Γ) ⟶ s[i].Ty) (B : y(s[i].ext A)
   conv at this => enter [1, 3]; apply s.dependent_eq
   simp [this]
 
+end Sigma
+
 /-! ## Identity types -/
 
 /--
@@ -880,5 +880,3 @@ theorem mkIdRec_mkRefl {Γ : Ctx} (A : y(Γ) ⟶ s[i].Ty)
     s.mkIdRec ilen jlen A t t_tp B B_eq M r r_tp t t_tp
       (s.mkRefl ilen t) (s.mkRefl_tp ilen _ t t_tp) = r := by
   sorry
-
-end UHomSeqPiSig

--- a/GroupoidModel/Syntax/UHom.lean
+++ b/GroupoidModel/Syntax/UHom.lean
@@ -2,7 +2,6 @@ import GroupoidModel.Syntax.NaturalModel
 import GroupoidModel.ForMathlib
 import Mathlib.CategoryTheory.Limits.Shapes.StrictInitial
 import GroupoidModel.ForPoly
-import GroupoidModel.Tactic.PrintSorries
 
 /-! Morphisms of natural models, and Russell-universe embeddings. -/
 


### PR DESCRIPTION
* [ ] depends on #126

This allows using them as mixins and avoids issues with `s[i]` and `s.toUHomSeq[i]` not being the same. We might want to have one typeclass extending both to make things simpler in `Interpretation.lean`.