### PR TITLE
perf: speed up soundness proof

### DIFF
--- a/GroupoidModel/Syntax/Interpretation.lean
+++ b/GroupoidModel/Syntax/Interpretation.lean
@@ -797,6 +797,10 @@ theorem var_sound {Γ i A l} (H : Lookup Γ i A l) {sΓ} (hΓ : sΓ ∈ ofCtx s 
   obtain ⟨_, h1, rfl⟩ := h1
   exact ⟨llen, _, h1, h2⟩
 
+/- The inductive soundness proof takes very long to typecheck,
+so we state the inductive hypotheses as definitions
+and break the inductive cases out into many small lemmas. -/
+
 def WfCtxIH Γ := ∃ sΓ, sΓ ∈ ofCtx s Γ
 def WfTpIH Γ l A := ∃ sΓ ∈ ofCtx s Γ, ∃ llen, ∃ sA, sA ∈ ofType sΓ l A llen
 def EqTpIH Γ l A B := ∃ sΓ ∈ ofCtx s Γ, ∃ llen, ∃ sA ∈ ofType sΓ l A llen, sA ∈ ofType sΓ l B llen

--- a/GroupoidModel/Syntax/UHom.lean
+++ b/GroupoidModel/Syntax/UHom.lean
@@ -627,7 +627,7 @@ end Pi
 
 /-! ## Sigma -/
 
-/-- The data of `Sig` and `pair` formers at each universe `s[i].tp`.
+/-- The data of `Sig` and `pair` formers at each universe `s[i].tp`. -/
 class SigSeq (s : UHomSeq Ctx) where
   nmSig (i : Nat) (ilen : i < s.length + 1 := by get_elem_tactic) : NaturalModel.Sigma s[i]
 


### PR DESCRIPTION
* [x] depends on #127 

Breaks out each case of `ofType_ofTerm_sound` into its own lemma. Doing this (with some sensible abbreviations) and dropping unnecessary variables makes the proof *much* faster and also easier to maintain. It also allows reducing a lot of duplication in the proof, for example because every typing rule is a special case of a conversion rule. The file is now 47s to check instead of 9 minutes.