### PR TITLE
feat: better support for internal sorry

### DIFF
--- a/GroupoidModel/Syntax/Frontend/Checked.lean
+++ b/GroupoidModel/Syntax/Frontend/Checked.lean
@@ -15,6 +15,7 @@ structure CheckedAx (E : Axioms χ) where
   wf_nfTp : ValEqTp E [] l nfTp tp
 
 namespace CheckedAx
+
 theorem wf_tp (a : CheckedAx E) : E ∣ [] ⊢[a.l] a.tp :=
   a.wf_nfTp.wf_tp
 

--- a/GroupoidModel/Syntax/Frontend/Commands.lean
+++ b/GroupoidModel/Syntax/Frontend/Commands.lean
@@ -26,9 +26,6 @@ def addCheckedAx (thyNm : Name) (ci : AxiomVal) : MetaM Unit := do
     try withEnv thyData.env <| translateAsTp ci.type |>.run env
     catch e =>
       throwError "failed to translate type{Lean.indentExpr ci.type}\nerror: {e.toMessageData}"
-  trace[Leanternal.Translation]
-    "axiom.\{{l}} {ci.name} :\
-        {Lean.indentExpr T |>.nest 2}"
 
   have axioms : Q(Axioms Name) := thyData.axioms
   have wf_axioms : Q(($axioms).Wf) := thyData.wf_axioms
@@ -78,11 +75,6 @@ def addCheckedDef (thyNm : Name) (ci : DefinitionVal) : MetaM Unit := do
     catch e =>
       throwError "failed to translate term{Lean.indentExpr ci.value}\nerror: {e.toMessageData}"
   if l != k then throwError "internal error: inferred level mismatch"
-  trace[Leanternal.Translation]
-    "def.\{{l}} {ci.name} :\
-        {Lean.indentExpr T |>.nest 2}\n\
-    :=\
-      {Lean.indentExpr t}"
 
   have axioms : Q(Axioms Name) := thyData.axioms
   have wf_axioms : Q(($axioms).Wf) := thyData.wf_axioms

--- a/GroupoidModel/Syntax/Frontend/Commands.lean
+++ b/GroupoidModel/Syntax/Frontend/Commands.lean
@@ -4,6 +4,46 @@ import GroupoidModel.Syntax.Typechecker.Synth
 import GroupoidModel.Syntax.Frontend.EnvExt
 import GroupoidModel.Syntax.Frontend.Translation
 
+-- TODO: backported from newer Lean; remove when bumping.
+namespace Lean
+namespace CollectAxioms'
+
+structure State where
+  visited : NameSet    := {}
+  axioms  : Array Name := #[]
+
+abbrev M := ReaderT Environment $ StateM State
+
+partial def collect (c : Name) : M Unit := do
+  let collectExpr (e : Expr) : M Unit := e.getUsedConstants.forM collect
+  let s ← get
+  unless s.visited.contains c do
+    modify fun s => { s with visited := s.visited.insert c }
+    let env ← read
+    -- We should take the constant from the kernel env, which may differ from the one in the elab
+    -- env in case of (async) errors.
+    match env.checked.get.find? c with
+    | some (ConstantInfo.axiomInfo v)  =>
+        modify fun s => { s with axioms := (s.axioms.push c) }
+        collectExpr v.type
+    | some (ConstantInfo.defnInfo v)   => collectExpr v.type *> collectExpr v.value
+    | some (ConstantInfo.thmInfo v)    => collectExpr v.type *> collectExpr v.value
+    | some (ConstantInfo.opaqueInfo v) => collectExpr v.type *> collectExpr v.value
+    | some (ConstantInfo.quotInfo _)   => pure ()
+    | some (ConstantInfo.ctorInfo v)   => collectExpr v.type
+    | some (ConstantInfo.recInfo v)    => collectExpr v.type
+    | some (ConstantInfo.inductInfo v) => collectExpr v.type *> v.ctors.forM collect
+    | none                             => pure ()
+
+end CollectAxioms'
+
+def collectAxioms' {m : Type → Type} [Monad m] [MonadEnv m] (constName : Name) : m (Array Name) := do
+  let env ← getEnv
+  let (_, s) := ((CollectAxioms'.collect constName).run env).run {}
+  pure s.axioms
+
+end Lean
+
 namespace Leanternal
 
 open Lean Elab Command
@@ -17,18 +57,58 @@ def envDiff (old new : Environment) : Array ConstantInfo := Id.run do
     ret := ret.push i
   return ret
 
-/-- Add an axiom `ci` in the given theory
+/-- Find axioms used by the given constant in the given environment,
+and return them as an axiom environment.
+Assumes that all such axioms are present in the ambient environment
+as definitions of type `CheckedAx _` under the same name. -/
+def computeAxioms (thyEnv : Environment) (constNm : Name) : MetaM ((E : Q(Axioms Name)) × Q(($E).Wf)) := do
+  let axioms ← withEnv thyEnv <| collectAxioms' constNm
+  -- The output includes `constNm` if it is itself an axiom.
+  let axioms := axioms.filter (· != constNm)
+  -- Order the axioms by '`a` uses `b`'.
+  let mut axiomAxioms : Std.HashMap Name (Array Name) := {}
+  for axNm in axioms do
+    let axioms ← withEnv thyEnv <| collectAxioms' axNm
+    let axioms := axioms.filter (· != axNm)
+    axiomAxioms := axiomAxioms.insert axNm axioms
+  let mut axioms := axioms.qsort (fun a b => axiomAxioms[b]!.contains a)
+  -- HACK: replace `sorryAx` with our universe-monomorphic versions.
+  if let some i := axioms.findIdx? (· == ``sorryAx) then
+    axioms := axioms.set! i `sorryAx₀
+    for i in [1:univMax] do
+      axioms := axioms.push (Name.anonymous.str s!"sorryAx{Nat.subDigitChar i}")
+  let mut E : Q(Axioms Name) := q(.empty _)
+  let mut Ewf : Q(($E).Wf) := q(Axioms.empty_wf _)
+  for axNm in axioms do
+    let axCi ← getConstInfo axNm
+    if !axCi.type.isAppOfArity' ``CheckedAx 2 then
+      throwError "checked axiom '{axNm}' has unexpected type{indentExpr axCi.type}"
+    let #[_, axE] := axCi.type.getAppArgs | throwError "internal error"
+    have axE : Q(Axioms Name) := axE
+    have ax : Q(CheckedAx $axE) := .const axNm []
+    -- (Aux `have`s work around bugs in Qq elaboration.)
+    have E' : Q(Axioms Name) := E
+    have Ewf' : Q(($E').Wf) := Ewf
+    let .inr get_name ← lookupAxiom q($E') q(($ax).name) | continue
+    let le ← checkAxiomsLe q($axE) q($E')
+    let E'' : Q(Axioms Name) :=
+      q(($E').snoc ($ax).l ($ax).name ($ax).tp ($ax).wf_tp.le_univMax ($ax).wf_tp.isClosed)
+    let Ewf'' : Q(($E'').Wf) :=
+      q(($Ewf').snoc ($ax).name (($ax).wf_tp.of_axioms_le $le) $get_name)
+    E := E''
+    Ewf := Ewf''
+  return ⟨E, Ewf⟩
+
+/-- Add an axiom `ci` defined in environment `thyEnv`
 to the Lean environment as a `CheckedAx`. -/
-def addCheckedAx (thyNm : Name) (ci : AxiomVal) : MetaM Unit := do
-  let thyData ← getTheoryData thyNm
+def addCheckedAx (thyEnv : Environment) (ci : AxiomVal) : MetaM Unit := do
   let env ← getEnv
   let (l, T) ←
-    try withEnv thyData.env <| translateAsTp ci.type |>.run env
+    try withEnv thyEnv <| translateAsTp ci.type |>.run env
     catch e =>
       throwError "failed to translate type{Lean.indentExpr ci.type}\nerror: {e.toMessageData}"
 
-  have axioms : Q(Axioms Name) := thyData.axioms
-  have wf_axioms : Q(($axioms).Wf) := thyData.wf_axioms
+  let ⟨axioms, wf_axioms⟩ ← computeAxioms thyEnv ci.name
   have name : Q(Name) := toExpr ci.name
   let .inr _ ← lookupAxiom q($axioms) q($name)
     | throwError "internal error: axiom '{ci.name}' has already been added, \
@@ -54,30 +134,22 @@ def addCheckedAx (thyNm : Name) (ci : AxiomVal) : MetaM Unit := do
     hints := .regular 0 -- TODO: what height?
     safety := .safe
   }
-  have a : Q(CheckedAx $axioms) := .const ci.name []
 
-  setTheoryData thyNm { thyData with
-    axioms := q(($a).snocAxioms)
-    wf_axioms := q(($a).wf_snocAxioms $wf_axioms)
-  }
-
-/-- Add a definition `ci` in the given theory
+/-- Add a definition `ci` defined in environment `thyEnv`
 to the Lean environment as a `CheckedDef`. -/
-def addCheckedDef (thyNm : Name) (ci : DefinitionVal) : MetaM Unit := do
-  let thyData ← getTheoryData thyNm
+def addCheckedDef (thyEnv : Environment) (ci : DefinitionVal) : MetaM Unit := do
   let env ← getEnv
   let (l, T) ←
-    try withEnv thyData.env <| translateAsTp ci.type |>.run env
+    try withEnv thyEnv <| translateAsTp ci.type |>.run env
     catch e =>
       throwError "failed to translate type{Lean.indentExpr ci.type}\nerror: {e.toMessageData}"
   let (k, t) ←
-    try withEnv thyData.env <| translateAsTm ci.value |>.run env
+    try withEnv thyEnv <| translateAsTm ci.value |>.run env
     catch e =>
       throwError "failed to translate term{Lean.indentExpr ci.value}\nerror: {e.toMessageData}"
   if l != k then throwError "internal error: inferred level mismatch"
 
-  have axioms : Q(Axioms Name) := thyData.axioms
-  have wf_axioms : Q(($axioms).Wf) := thyData.wf_axioms
+  let ⟨axioms, wf_axioms⟩ ← computeAxioms thyEnv ci.name
   let Twf ← checkTp q($axioms) q($wf_axioms) q([]) q($l) q($T)
   let ⟨vT, vTeq⟩ ← evalTpId q(show TpEnv Lean.Name from []) q($T)
   let twf ← checkTm q($axioms) q($wf_axioms) q([]) q($l) q($vT) q($t)
@@ -105,26 +177,26 @@ def elabAxiom (thyNm : Name) (stx : Syntax) : CommandElabM Unit := do
   let thyEnv' ← withEnv thyData.env do Command.elabDeclaration stx; getEnv
   if ← MonadLog.hasErrors then
     return
+  setTheoryData thyNm { thyData with env := thyEnv' }
   let diff := envDiff thyData.env thyEnv'
-  let #[.axiomInfo ci] := diff
+  let #[.axiomInfo i] := diff
     | throwError "expected exactly one axiom, got {diff.size}:\
       {Lean.indentD ""}{diff.map (·.name)}"
-  Command.liftTermElabM <| addCheckedAx thyNm ci
-  saveShallowTheoryConst thyNm (.axiomInfo ci)
-  modifyTheoryData thyNm fun d => { d with env := thyEnv' }
+  saveShallowTheoryConst thyNm (.axiomInfo i)
+  Command.liftTermElabM <| addCheckedAx thyEnv' i
 
 def elabDeclaration (thyNm : Name) (stx : Syntax) : CommandElabM Unit := do
   let thyData ← getTheoryData thyNm
   let thyEnv' ← withEnv thyData.env do Command.elabDeclaration stx; getEnv
   if ← MonadLog.hasErrors then
     return
+  setTheoryData thyNm { thyData with env := thyEnv' }
   let diff := envDiff thyData.env thyEnv'
-  let #[.defnInfo ci] := diff
+  let #[.defnInfo i] := diff
     | throwError "expected exactly one definition, got {diff.size}:\
       {Lean.indentD ""}{diff.map (·.name)}"
-  Command.liftTermElabM <| addCheckedDef thyNm ci
-  saveShallowTheoryConst thyNm (.defnInfo ci)
-  modifyTheoryData thyNm fun d => { d with env := thyEnv' }
+  saveShallowTheoryConst thyNm (.defnInfo i)
+  Command.liftTermElabM <| addCheckedDef thyEnv' i
 
 /-- Declare a new Leanternal theory with the given name.
 Theories start off with no axioms or definitions.
@@ -133,12 +205,6 @@ where `<theory>` is your chosen name. -/
 elab "declare_theory " thy:ident : command => do
   let thyNm := thy.getId
   saveTheoryDecl thyNm
-  let thyData ← getTheoryData thyNm
-  for i in [0:univMax] do
-    let nm := Name.anonymous.str s!"sorryAx{Nat.subDigitChar i}"
-    let .axiomInfo ci ← withEnv thyData.env <| getConstInfo nm
-      | throwError "internal error: could not find axiom '{nm}' in theory environment"
-    Command.liftTermElabM <| addCheckedAx thyNm ci
   let pre : TSyntax `str := quote s!"{thyNm} "
   -- Bug: `command` written directly inside the quotation is hygienized,
   -- and then the quoted command fails to run.
@@ -158,5 +224,26 @@ elab "declare_theory " thy:ident : command => do
       | ``Parser.Command.axiom => elabAxiom $(quote thyNm) cmd
       | _ => throwError "unhandled command:{indentD cmd}"
   )
+
+-- Reflect definitions from the prelude as `Checked*`.
+run_meta do
+  let thyData ← mkInitTheoryData default default
+  let addAx (nm : Name) := do
+    let .axiomInfo i ← withEnv thyData.env <| getConstInfo nm | throwError "internal error"
+    addCheckedAx thyData.env i
+  let addDef (nm : Name) := do
+    let .defnInfo i ← withEnv thyData.env <| getConstInfo nm | throwError "internal error"
+    addCheckedDef thyData.env i
+  -- TODO: fold
+  addDef `Identity.rfl₀
+  addDef `Identity.rfl₁
+  addDef `Identity.symm₀
+  addDef `Identity.symm₁
+  addDef `Identity.trans₀
+  addDef `Identity.trans₁
+  addAx `sorryAx₀
+  addAx `sorryAx₁
+  addAx `sorryAx₂
+  addAx `sorryAx₃
 
 end Leanternal

--- a/GroupoidModel/Syntax/Frontend/Commands.lean
+++ b/GroupoidModel/Syntax/Frontend/Commands.lean
@@ -103,8 +103,8 @@ def computeAxioms (thyEnv : Environment) (constNm : Name) : MetaM ((E : Q(Axioms
 to the Lean environment as a `CheckedAx`. -/
 def addCheckedAx (thyEnv : Environment) (ci : AxiomVal) : MetaM Unit := do
   let env ← getEnv
-  let (l, T) ←
-    try withEnv thyEnv <| translateAsTp ci.type |>.run env
+  let (l, T) ← withEnv thyEnv do
+    try translateAsTp ci.type |>.run env
     catch e =>
       throwError "failed to translate type{Lean.indentExpr ci.type}\nerror: {e.toMessageData}"
 
@@ -139,12 +139,12 @@ def addCheckedAx (thyEnv : Environment) (ci : AxiomVal) : MetaM Unit := do
 to the Lean environment as a `CheckedDef`. -/
 def addCheckedDef (thyEnv : Environment) (ci : DefinitionVal) : MetaM Unit := do
   let env ← getEnv
-  let (l, T) ←
-    try withEnv thyEnv <| translateAsTp ci.type |>.run env
+  let (l, T) ← withEnv thyEnv do
+    try translateAsTp ci.type |>.run env
     catch e =>
       throwError "failed to translate type{Lean.indentExpr ci.type}\nerror: {e.toMessageData}"
-  let (k, t) ←
-    try withEnv thyEnv <| translateAsTm ci.value |>.run env
+  let (k, t) ← withEnv thyEnv do
+    try translateAsTm ci.value |>.run env
     catch e =>
       throwError "failed to translate term{Lean.indentExpr ci.value}\nerror: {e.toMessageData}"
   if l != k then throwError "internal error: inferred level mismatch"

--- a/GroupoidModel/Syntax/Frontend/EnvExt.lean
+++ b/GroupoidModel/Syntax/Frontend/EnvExt.lean
@@ -61,12 +61,6 @@ structure TheoryData where
 
   New definitions and axioms are elaborated in this environment. -/
   env : Environment
-  /-- The deeply embedded set of theory axioms.
-
-  Equivalently, a cache for something like
-  `env.filter (·.isAxiom) |>.fold q(Env.empty Name) fun acc ax => q($acc.snoc ax)`. -/
-  axioms : Q(Axioms Name)
-  wf_axioms : Q(($axioms).Wf)
 
 private abbrev TheoryExt := SimplePersistentEnvExtension TheoryEntry (NameMap TheoryData)
 
@@ -74,7 +68,7 @@ private abbrev TheoryExt := SimplePersistentEnvExtension TheoryEntry (NameMap Th
 
 For the initial shallow environment,
 we pull in a custom prelude with `Type`-valued identity types. -/
-private def mkInitTheoryData (modNm mainModule : Name) : m TheoryData := do
+def mkInitTheoryData (modNm mainModule : Name) : m TheoryData := do
   -- TODO: check if the `.olean` exists and print a better error if not.
   let mut thyEnv ← importModules #[{ module := `GroupoidModel.Syntax.Frontend.Prelude }]
     (← getOptions) (leakEnv := true) (loadExts := true)
@@ -82,8 +76,6 @@ private def mkInitTheoryData (modNm mainModule : Name) : m TheoryData := do
   return {
     modNm
     env := thyEnv
-    axioms := q(.empty Name)
-    wf_axioms := q(Axioms.empty_wf Name)
   }
 
 private initialize theoryExt : TheoryExt ←
@@ -111,26 +103,13 @@ private initialize theoryExt : TheoryExt ←
             let some thyData := thyMap.find? thyNm
               | throwThe IO.Error
                   s!"corrupt olean: appending '{ci.name}' to non-existent theory '{thyNm}'"
-            match ci with
-            | .defnInfo i =>
-              -- Q: no extension entries added after the prelude; will this break elaboration?
-              let .ok thyEnv := thyData.env.addDeclCore 0 (.defnDecl i) none (doCheck := false)
-                | throwThe IO.Error "internal error" /- cannot happen with `doCheck := false` -/
-
-              thyMap := thyMap.insert thyNm { thyData with env := thyEnv }
-            | .axiomInfo i =>
-              let .ok thyEnv := thyData.env.addDeclCore 0 (.axiomDecl i) none (doCheck := false)
-                | throwThe IO.Error "internal error" /- cannot happen with `doCheck := false` -/
-
-              have axioms : Q(Axioms Name) := thyData.axioms
-              have wf_axioms : Q(($axioms).Wf) := thyData.wf_axioms
-              have a : Q(CheckedAx $axioms) := .const ci.name []
-              thyMap := thyMap.insert thyNm { thyData with
-                env := thyEnv,
-                axioms := q(($a).snocAxioms)
-                wf_axioms := q(($a).wf_snocAxioms $wf_axioms)
-              }
-            | _ => throwThe IO.Error s!"unexpected constant info kind at '{ci.name}'"
+            let decl ← match ci with
+              | .axiomInfo i => pure <| .axiomDecl i | .defnInfo i => pure <| .defnDecl i
+              | _ => throwThe IO.Error s!"unsupported constant kind at '{ci.name}'"
+            -- Q: no extension entries added after the prelude; will this break elaboration?
+            let .ok thyEnv := thyData.env.addDeclCore 0 decl none (doCheck := false)
+              | throwThe IO.Error "internal error" /- cannot happen with `doCheck := false` -/
+            thyMap := thyMap.insert thyNm { thyData with env := thyEnv }
       return ([], thyMap)
     /- We update only the list of entries; theory data needs a monadic computation to update. -/
     addEntryFn s e := (e :: s.1, s.2)
@@ -176,9 +155,5 @@ def setTheoryData (thyNm : Name) (thyData : TheoryData) : m Unit := do
   if !thyMap.contains thyNm then
     throwError "trying to write non-existent theory '{thyNm}'"
   setEnv <| theoryExt.modifyState env fun ds => ds.insert thyNm thyData
-
-def modifyTheoryData (thyNm : Name) (f : TheoryData → TheoryData) : m Unit := do
-  let thyData ← getTheoryData thyNm
-  setTheoryData thyNm <| f thyData
 
 end Leanternal

--- a/GroupoidModel/Syntax/Frontend/EnvExt.lean
+++ b/GroupoidModel/Syntax/Frontend/EnvExt.lean
@@ -141,7 +141,9 @@ private initialize theoryExt : TheoryExt ←
     -- TODO: statsFn, asyncMode, replay?
   }
 
-/-- Persistently store a new theory declaration. -/
+/-- Initialize the data of a new theory,
+importing `Frontend.Prelude` into the initial shallow environment,
+and persistently store the theory declaration. -/
 def saveTheoryDecl (thyNm : Name) : m Unit := do
   let mut env ← getEnv
   let st := PersistentEnvExtension.getState theoryExt env
@@ -161,7 +163,6 @@ def saveShallowTheoryConst (thyNm : Name) (ci : ConstantInfo) : m Unit := do
     throwError "trying to modify non-existent theory '{thyNm}'"
   setEnv <| theoryExt.addEntry env (.const thyNm ci)
 
-/-- Retrieve cached data for the given theory. -/
 def getTheoryData (thyNm : Name) : m TheoryData := do
   let env ← getEnv
   let thyMap := theoryExt.getState env
@@ -169,12 +170,15 @@ def getTheoryData (thyNm : Name) : m TheoryData := do
     | throwError "trying to read non-existent theory '{thyNm}'"
   return thyData
 
-/-- Set cached data for the given theory. -/
 def setTheoryData (thyNm : Name) (thyData : TheoryData) : m Unit := do
   let env ← getEnv
   let thyMap := theoryExt.getState env
   if !thyMap.contains thyNm then
     throwError "trying to write non-existent theory '{thyNm}'"
   setEnv <| theoryExt.modifyState env fun ds => ds.insert thyNm thyData
+
+def modifyTheoryData (thyNm : Name) (f : TheoryData → TheoryData) : m Unit := do
+  let thyData ← getTheoryData thyNm
+  setTheoryData thyNm <| f thyData
 
 end Leanternal

--- a/GroupoidModel/Syntax/Frontend/Prelude.lean
+++ b/GroupoidModel/Syntax/Frontend/Prelude.lean
@@ -12,11 +12,32 @@ universe u
 inductive Identity {α : Type u} : α → α → Type u where
   | refl (a : α) : Identity a a
 
-@[match_pattern] def Identity.rfl {α : Type u} {a : α} : Identity a a :=
+namespace Identity
+
+-- FIXME: add universe polymorphism via `(l : Nat) → { d : CheckedAx .. // d.l = l }`
+@[match_pattern] def rfl₀ {α : Type 0} {a : α} : Identity a a :=
   Identity.refl a
 
+@[match_pattern] def rfl₁ {α : Type 1} {a : α} : Identity a a :=
+  Identity.refl a
+
+@[symm] noncomputable def symm₀ {α : Type 0} {a b : α} (h : Identity a b) : Identity b a :=
+  h.rec .rfl₀
+
+@[symm] noncomputable def symm₁ {α : Type 1} {a b : α} (h : Identity a b) : Identity b a :=
+  h.rec .rfl₁
+
+noncomputable def trans₀ {α : Type 0} {a b c : α} (h₁ : Identity a b) (h₂ : Identity b c) :
+    Identity a c :=
+  h₂.rec h₁
+
+noncomputable def trans₁ {α : Type 1} {a b c : α} (h₁ : Identity a b) (h₂ : Identity b c) :
+    Identity a c :=
+  h₂.rec h₁
+
+end Identity
+
 -- Rudimentary support for `sorry`.
--- FIXME: add universe polymorphism via `(l : Nat) → { d : CheckedAx .. // d.l = l }`
 axiom sorryAx₀ (A : Type 0) : A
 axiom sorryAx₁ (A : Type 1) : A
 axiom sorryAx₂ (A : Type 2) : A

--- a/GroupoidModel/Syntax/Frontend/Prelude.lean
+++ b/GroupoidModel/Syntax/Frontend/Prelude.lean
@@ -14,3 +14,10 @@ inductive Identity {α : Type u} : α → α → Type u where
 
 @[match_pattern] def Identity.rfl {α : Type u} {a : α} : Identity a a :=
   Identity.refl a
+
+-- Rudimentary support for `sorry`.
+-- FIXME: add universe polymorphism via `(l : Nat) → { d : CheckedAx .. // d.l = l }`
+axiom sorryAx₀ (A : Type 0) : A
+axiom sorryAx₁ (A : Type 1) : A
+axiom sorryAx₂ (A : Type 2) : A
+axiom sorryAx₃ (A : Type 3) : A

--- a/GroupoidModel/Syntax/Frontend/Translation.lean
+++ b/GroupoidModel/Syntax/Frontend/Translation.lean
@@ -198,7 +198,6 @@ partial def translateAsTm (e : Lean.Expr) : TranslateM (Nat × Q(_root_.Expr Lea
     -- We translate internal constants to projections from external constants.
     let ci ← getConstInfo nm
     withEnv (← read).extEnv do
-    withLCtx {} {} do
       match ci with
       | .defnInfo i => return ⟨n, ← mkAppM ``CheckedDef.val #[.const i.name []]⟩
       | .axiomInfo i => return ⟨n, ← mkAppM ``CheckedAx.val #[.const i.name []]⟩

--- a/GroupoidModel/Syntax/Frontend/Translation.lean
+++ b/GroupoidModel/Syntax/Frontend/Translation.lean
@@ -1,6 +1,5 @@
 import Qq
 import GroupoidModel.Syntax.Axioms
-import GroupoidModel.Syntax.Frontend.Prelude
 import GroupoidModel.Syntax.Frontend.Checked
 
 namespace Leanternal
@@ -11,6 +10,8 @@ def traceClsTranslation : Name := `Leanternal.Translation
 
 initialize
   registerTraceClass traceClsTranslation
+  registerTraceClass (traceClsTranslation ++ `tp) (inherited := true)
+  registerTraceClass (traceClsTranslation ++ `tm) (inherited := true)
 
 structure Context where
   /-- Maps `FVarId`s to their de Bruijn index. -/
@@ -65,6 +66,11 @@ mutual
 /-- Completeness: if the argument is well-formed in Lean,
 the output is well-typed in MLTT. -/
 partial def translateAsTp (e : Lean.Expr) : TranslateM (Nat × Q(_root_.Expr Lean.Name)) := do
+  Lean.withTraceNode (ε := Lean.Exception) (traceClsTranslation ++ `tp) (fun
+    | .ok ⟨l, A⟩ => do
+      let mA : MessageData ← withEnv (← read).extEnv <| addMessageContextPartial A
+      return m!"✅️ {e} [{l}]⇒ {mA}"
+    | .error _ => return m!"❌️ {e} ⇒ _") do
   if !isType e then
     let ⟨l+1, a⟩ ← translateAsTm e
       | throwError "type code should have level > 0{indentExpr e}"
@@ -83,6 +89,11 @@ partial def translateAsTp (e : Lean.Expr) : TranslateM (Nat × Q(_root_.Expr Lea
   | _ => throwError "internal error: should fail `isType`{indentExpr e}"
 
 partial def translateAsTm (e : Lean.Expr) : TranslateM (Nat × Q(_root_.Expr Lean.Name)) := do
+  Lean.withTraceNode (ε := Lean.Exception) (traceClsTranslation ++ `tm) (fun
+    | .ok ⟨l, a⟩ => do
+      let ma : MessageData ← withEnv (← read).extEnv <| addMessageContextPartial a
+      return m!"✅️ {e} [{l}]⇒ {ma}"
+    | .error _ => return m!"❌️ {e} ⇒ _") do
   if isType e then
     let ⟨l, A⟩ ← translateAsTp e
     return ⟨l+1, q(.code $A)⟩
@@ -102,6 +113,24 @@ partial def translateAsTm (e : Lean.Expr) : TranslateM (Nat × Q(_root_.Expr Lea
       withBinder x <| translateAsTm b
     return ⟨max l l', q(.lam $l $l' $A $b)⟩
   | .app fn arg => do
+    if e.isAppOfArity' ``sorryAx 3 then
+      let #[A, _, _] := e.getAppArgs | throwError "internalError"
+      -- Recent versions of Lean generate ``sorryAx (Name → ActualType) `«sourceLocation»``.
+      -- In `Frontend.Prelude` we have defined `sorryAxₗ` for `l < univMax`.
+      -- We translate the former to the latter.
+      let ⟨l, A⟩ ← forallBoundedTelescope A (some 1) fun xs A' => do
+        let #[x] := xs | throwError "internal error (sorryAx)"
+        let tp ← inferType x
+        if !(← isDefEq tp q(Lean.Name)) then
+          throwError "unexpected type of sorryAx{Lean.indentExpr A}"
+        translateAsTp A'
+      let sl : Nat := l + 1
+      let name : Q(Lean.Name) := toExpr <|
+        Lean.Name.anonymous.str s!"sorryAx{Nat.subDigitChar l}"
+      return ⟨l,
+        q(.app $sl $l (.el <| .bvar 0)
+          (.ax $name (.pi $sl $l (.univ $l) (.el <| .bvar 0)))
+          (.code $A))⟩
     if e.isAppOfArity' ``Sigma.mk 4 then
       let #[_, B, f, s] := e.getAppArgs | throwError "internal error"
       let ⟨l', B⟩ ← lambdaBoundedTelescope B 1 fun xs B => do
@@ -114,7 +143,7 @@ partial def translateAsTm (e : Lean.Expr) : TranslateM (Nat × Q(_root_.Expr Lea
       let #[A, B, p] := e.getAppArgs | throwError "internal error"
       let ⟨l, A⟩ ← translateAsTp A
       let ⟨l', B⟩ ← lambdaBoundedTelescope B 1 fun xs B => do
-        let #[x] := xs | throwError "internal error (Sigma.mk)"
+        let #[x] := xs | throwError "internal error (Sigma.fst)"
         withBinder x <| translateAsTp B
       let ⟨_, p⟩ ← translateAsTm p
       return ⟨l, q(.fst $l $l' $A $B $p)⟩
@@ -122,20 +151,20 @@ partial def translateAsTm (e : Lean.Expr) : TranslateM (Nat × Q(_root_.Expr Lea
       let #[A, B, p] := e.getAppArgs | throwError "internal error"
       let ⟨l, A⟩ ← translateAsTp A
       let ⟨l', B⟩ ← lambdaBoundedTelescope B 1 fun xs B => do
-        let #[x] := xs | throwError "internal error (Sigma.mk)"
+        let #[x] := xs | throwError "internal error (Sigma.snd)"
         withBinder x <| translateAsTp B
       let ⟨_, p⟩ ← translateAsTm p
       return ⟨l', q(.snd $l $l' $A $B $p)⟩
     -- Defined in `Syntax.Frontend.Prelude`.
-    if e.isAppOfArity' ``Identity.refl 2 then
+    if e.isAppOfArity' `Identity.refl 2 then
       let #[_, a] := e.getAppArgs | throwError "internal error (Id.refl)"
       let ⟨l, a⟩ ← translateAsTm a
       return ⟨l, q(.refl $l $a)⟩
-    if e.isAppOfArity' ``Identity.rec 6 then
+    if e.isAppOfArity' `Identity.rec 6 then
       let #[_, a, M, r, b, h] := e.getAppArgs | throwError "internal error (Id.rec)"
       let ⟨l, a⟩ ← translateAsTm a
       let ⟨l', M⟩ ← lambdaBoundedTelescope M 2 fun xs M => do
-        let #[x, h] := xs | throwError "internal error (Id.rec)"
+        let #[x, h] := xs | throwError "internal error (Id.rec motive)"
         withBinder x <| withBinder h <| translateAsTp M
       let ⟨_, r⟩ ← translateAsTm r
       let ⟨_, b⟩ ← translateAsTm b
@@ -159,7 +188,7 @@ partial def translateAsTm (e : Lean.Expr) : TranslateM (Nat × Q(_root_.Expr Lea
     let l ← getSortLevel l.succ
     let l' ← getSortLevel l'.succ
     return ⟨max l l' + 1, mkSigma _ l l'⟩
-  | .const ``Identity [l] =>
+  | .const `Identity [l] =>
     let l ← getSortLevel l.succ
     return ⟨l + 1, mkId _ l⟩
   | .const nm [] =>

--- a/GroupoidModel/Syntax/Typechecker/Evaluate.lean
+++ b/GroupoidModel/Syntax/Typechecker/Evaluate.lean
@@ -344,6 +344,9 @@ partial def evalNeutTm (env : Q(List (Val $χ))) (nt : Q(Neut $χ)) :
         ValEqTm E Δ l $v (t.subst σ) (A.subst σ))) := do
   match nt with
   | ~q(.ax $c $vA) =>
+    -- FIXME: should be possible to skip reevaluating `vA` as it's closed,
+    -- so should be WF in any context.
+    let ⟨vA, vApost⟩ ← evalValTp q($env) q($vA)
     return ⟨q(.neut (.ax $c $vA) $vA), q(by as_aux_lemma =>
       introv env nt
       have ⟨Al, _, Ec, vA, eqt, eq⟩ := nt.inv_ax
@@ -352,8 +355,7 @@ partial def evalNeutTm (env : Q(List (Val $χ))) (nt : Q(Neut $χ)) :
       apply ValEqTm.conv_tp _ (eq.subst env.wf_sb).symm_tp
       simp only [Expr.subst, Expr.subst_of_isClosed _ Al.2.1]
       refine have h := ?_; ValEqTm.neut_tm h (.ax env.wf_dom Ec h)
-      -- TODO: `vA` is closed, so WF in any context
-      sorry
+      simpa [Expr.subst_of_isClosed _ Al.2.1] using $vApost env vA
     )⟩
   | ~q(.bvar $i) =>
     let v : Q(Option (Val $χ)) ← Lean.Meta.whnf q($env[($env).length - $i - 1]?)

--- a/GroupoidModel/Syntax/Typechecker/Synth.lean
+++ b/GroupoidModel/Syntax/Typechecker/Synth.lean
@@ -170,7 +170,7 @@ partial def synthTm (vΓ : Q(TpEnv Lean.Name)) (l : Q(Nat)) (t : Q(Expr Lean.Nam
       ∃ T, ValEqTp $E Γ $l $vT T ∧ ($E ∣ Γ ⊢[$l] ($t) : T))) :=
   Lean.withTraceNode (ε := Lean.Exception) traceClsTypechecker (fun
     | .ok ⟨vT, _⟩ => return m!"✅️ {vΓ} ⊢[{l}] {t} ⇒ {vT}"
-    | .error e => return m!"❌️ {vΓ} ⊢[{l}] {t} ⇒ _") do
+    | .error _ => return m!"❌️ {vΓ} ⊢[{l}] {t} ⇒ _") do
   match t with
   | ~q(@CheckedDef.val _ $E' $defn) => do
     -- Ensure the definition uses a subset of the available axioms.

--- a/GroupoidModel/Syntax/Typechecker/Synth.lean
+++ b/GroupoidModel/Syntax/Typechecker/Synth.lean
@@ -40,50 +40,56 @@ partial def lookupAxiom (E : Q(Axioms Lean.Name)) (c : Q(Lean.Name)) : Lean.Meta
       Q($E $c = none)) := do
   match E with
   | ~q(.empty _) => return .inr q(by rfl)
-  | ~q(@CheckedAx.snocAxioms _ $E' $ax) =>
-    let b : Q(Bool) ← Lean.Meta.whnf q(decide (($ax).name = $c))
-    have : $b =Q decide (($ax).name = $c) := .unsafeIntro
+  | ~q(Axioms.snoc $E' $l $c' $A $l_le $A_cl) =>
+    let b : Q(Bool) ← Lean.Meta.whnf q(decide ($c' = $c))
+    have : $b =Q decide ($c' = $c) := .unsafeIntro
     match b with
     | ~q(true) =>
-      return Sum.inl ⟨q($(ax).tp), q(($ax).l), q(by as_aux_lemma =>
-        have : ($ax).name = $c := by rwa [decide_eq_true_iff] at *
-        simp +zetaDelta [CheckedAx.snocAxioms, this, ($ax).wf_tp.isClosed, ($ax).wf_tp.le_univMax]
+      return Sum.inl ⟨q($A), q($l), q(by as_aux_lemma =>
+        have : $c' = $c := by rwa [decide_eq_true_iff] at *
+        simp +zetaDelta [this, ($A_cl), ($l_le)]
       )⟩
     | ~q(false) =>
       match ← lookupAxiom q($E') q($c) with
       | .inl ⟨A, l, h⟩ =>
         return .inl ⟨A, l, q(by as_aux_lemma =>
-          have : ($ax).name ≠ $c := by rwa [decide_eq_false_iff_not] at *
+          have : $c' ≠ $c := by rwa [decide_eq_false_iff_not] at *
           have ⟨h, eq⟩ := $h
           refine ⟨h, ?_⟩
           simpa +zetaDelta [CheckedAx.snocAxioms, Axioms.snoc, this.symm] using eq
         )⟩
       | .inr h =>
         return .inr q(by as_aux_lemma =>
-          have : ($ax).name ≠ $c := by rwa [decide_eq_false_iff_not] at *
+          have : $c' ≠ $c := by rwa [decide_eq_false_iff_not] at *
           simpa +zetaDelta [CheckedAx.snocAxioms, Axioms.snoc, this.symm] using $h
         )
     | _ =>
       throwError "could not determine whether\
-          {Lean.indentExpr q(($ax).name) |>.nest 2}\
+          {Lean.indentExpr q($c') |>.nest 2}\
         {Lean.indentD "="}\
           {Lean.indentExpr c |>.nest 2}"
+  | ~q(CheckedAx.snocAxioms _) =>
+    let E ← Lean.Meta.unfoldDefinition E
+    lookupAxiom E c
   | _ => throwError "unsupported axiom environment{Lean.indentExpr E}"
 
 partial def checkAxiomsLe (E E' : Q(Axioms Lean.Name)) : Lean.MetaM Q($E ≤ $E') := do
   match E with
   | ~q(.empty _) => return q(($E').empty_le)
-  | ~q(@CheckedAx.snocAxioms _ $E₀ $ax) =>
+  | ~q(Axioms.snoc $E₀ $l' $c' $A' $l_le $A_cl) =>
     let le ← checkAxiomsLe q($E₀) q($E')
-    let .inl ⟨A, l, En⟩ ← lookupAxiom q($E') q(($ax).name)
-      | throwError "could not prove that '{q(($ax).name)}' is contained in{Lean.indentExpr E'}"
-    let ⟨_⟩ ← assertDefEqQ q($A) q(($ax).tp)
-    let ⟨_⟩ ← assertDefEqQ q($l) q(($ax).l)
+    let .inl ⟨A, l, En⟩ ← lookupAxiom q($E') q($c')
+      | throwError "could not prove that '{c'}' is contained in{Lean.indentExpr E'}"
+    let ⟨_⟩ ← assertDefEqQ q($A) q($A')
+    let ⟨_⟩ ← assertDefEqQ q($l) q($l')
     return q(by as_aux_lemma =>
       dsimp +zetaDelta only [CheckedAx.snocAxioms]
       have ⟨_, h⟩ := $En
       apply Axioms.snoc_le $le _ _ _ _ _ h
     )
+  | ~q(CheckedAx.snocAxioms _) =>
+    let E ← Lean.Meta.unfoldDefinition E
+    checkAxiomsLe E E'
   | _ =>
     throwError "could not prove\
         {Lean.indentExpr E |>.nest 2}\

--- a/test/basic.lean
+++ b/test/basic.lean
@@ -2,9 +2,11 @@ import GroupoidModel.Syntax.Frontend.Commands
 
 /-! Test basic typechecker functionality. -/
 
-/-! ## Declaring a theory -/
+/-! ## Declaring theories -/
 
 declare_theory mltt
+
+declare_theory anothertt
 
 /-! ## Universes -/
 
@@ -78,3 +80,9 @@ mltt axiom c : C b
 mltt def Cb : Type := C b
 
 mltt noncomputable def c' : Cb := c
+
+/-! ## Using `sorry` -/
+
+/-- warning: declaration uses 'sorry' -/
+#guard_msgs in
+mltt def foo : Type := sorry


### PR DESCRIPTION
- Support internal `sorry`.
- Compute axiom environments in a more fine-grained way, based on which axioms have actually been used in the definition.